### PR TITLE
WIP: add SVHN dataset (Format 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,28 @@
 language: julia
-
 os:
-    - linux
-    - osx
-
+  - linux
+  - osx
 julia:
-    - 0.6
-    - nightly
-matrix:
-    allow_failures:
-        - julia: nightly
-git:
-    depth: 5000
-
+  - 0.6
+  - nightly
 notifications:
-    email: false
+  email: false
+git:
+  depth: 99999999
 
-before_script:
-  - export PATH=$HOME/.local/bin:$PATH
+matrix:
+  allow_failures:
+    - julia: nightly
+
+addons:
+  apt: # apt-get for linux
+    packages:
+      - hdf5-tools
 
 install:
   #- sudo pip install pymdown-extensions
 
 after_success:
+  - julia -e 'cd(Pkg.dir("MLDatasets")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("MLDatasets")); include(joinpath("docs", "make.jl"))'
-
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("MLDatasets"); Pkg.test("MLDatasets"; coverage=true)'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels`
 [**FashionMNIST**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/FashionMNIST/) | 10 | 28x28x60000 | 60000 | 28x28x10000 | 10000
 [**CIFAR-10**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/CIFAR10/) | 10 | 32x32x3x50000 | 50000 | 32x32x3x10000 | 10000
 [**CIFAR-100**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/CIFAR100/) | 100 (20) | 32x32x3x50000 | 50000 (x2) | 32x32x3x10000 | 10000 (x2)
+[**SVHN-2**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/SVHN2/)(*) | 10 | 32x32x3x73257 | 73257 | 32x32x3x26032 | 26032
+
+(*) Note that the SVHN-2 dataset provides an additional 531131 observations aside from the training- and testset
 
 ### Language Modeling
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels`
 [**FashionMNIST**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/FashionMNIST/) | 10 | 28x28x60000 | 60000 | 28x28x10000 | 10000
 [**CIFAR-10**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/CIFAR10/) | 10 | 32x32x3x50000 | 50000 | 32x32x3x10000 | 10000
 [**CIFAR-100**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/CIFAR100/) | 100 (20) | 32x32x3x50000 | 50000 (x2) | 32x32x3x10000 | 10000 (x2)
-[**SVHN-2**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/SVHN2/)(*) | 10 | 32x32x3x73257 | 73257 | 32x32x3x26032 | 26032
+[**SVHN-2**](https://juliaml.github.io/MLDatasets.jl/latest/datasets/SVHN2/) (*) | 10 | 32x32x3x73257 | 73257 | 32x32x3x26032 | 26032
 
 (*) Note that the SVHN-2 dataset provides an additional 531131 observations aside from the training- and testset
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ ColorTypes 0.4
 DataDeps
 GZip
 BinDeps
+MAT

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(
                 "Fashion MNIST" => "datasets/FashionMNIST.md",
                 "CIFAR-10" => "datasets/CIFAR10.md",
                 "CIFAR-100" => "datasets/CIFAR100.md",
+                "SVHN format 2" => "datasets/SVHN2.md",
             ],
         ],
         hide("Indices" => "indices.md"),

--- a/docs/src/datasets/SVHN2.md
+++ b/docs/src/datasets/SVHN2.md
@@ -62,8 +62,14 @@ Function | Description
 ---------|-------------
 [`download([dir])`](@ref SVHN2.download) | Trigger interactive download of the dataset
 [`classnames()`](@ref SVHN2.classnames) | Return the class names as a vector of strings
+[`traintensor([T], [indices]; [dir])`](@ref SVHN2.traintensor) | Load the training images as an array of eltype `T`
+[`trainlabels([indices]; [dir])`](@ref SVHN2.trainlabels) | Load the labels for the training images
 [`traindata([T], [indices]; [dir])`](@ref SVHN2.traindata) | Load images and labels of the training data
+[`testtensor([T], [indices]; [dir])`](@ref SVHN2.testtensor) | Load the test images as an array of eltype `T`
+[`testlabels([indices]; [dir])`](@ref SVHN2.testlabels) | Load the labels for the test images
 [`testdata([T], [indices]; [dir])`](@ref SVHN2.testdata) | Load images and labels of the test data
+[`extratensor([T], [indices]; [dir])`](@ref SVHN2.extratensor) | Load the extra images as an array of eltype `T`
+[`extralabels([indices]; [dir])`](@ref SVHN2.extralabels) | Load the labels for the extra training images
 [`extradata([T], [indices]; [dir])`](@ref SVHN2.extradata) | Load images and labels of the extra training data
 
 This module also provides utility functions to make working with
@@ -107,18 +113,24 @@ SVHN2
 ### Trainingset
 
 ```@docs
+SVHN2.traintensor
+SVHN2.trainlabels
 SVHN2.traindata
 ```
 
 ### Testset
 
 ```@docs
+SVHN2.testtensor
+SVHN2.testlabels
 SVHN2.testdata
 ```
 
 ### Extraset
 
 ```@docs
+SVHN2.extratensor
+SVHN2.extralabels
 SVHN2.extradata
 ```
 

--- a/docs/src/datasets/SVHN2.md
+++ b/docs/src/datasets/SVHN2.md
@@ -1,0 +1,140 @@
+# [The Street View House Numbers (SVHN) Dataset](@id SVHN2)
+
+Description from the [official
+website](http://ufldl.stanford.edu/housenumbers/):
+
+> SVHN is a real-world image dataset for developing machine
+> learning and object recognition algorithms with minimal
+> requirement on data preprocessing and formatting. It can be
+> seen as similar in flavor to MNIST (e.g., the images are of
+> small cropped digits), but incorporates an order of magnitude
+> more labeled data (over 600,000 digit images) and comes from a
+> significantly harder, unsolved, real world problem (recognizing
+> digits and numbers in natural scene images). SVHN is obtained
+> from house numbers in Google Street View images.
+
+About Format 2 (Cropped Digits):
+
+> All digits have been resized to a fixed resolution of 32-by-32
+> pixels. The original character bounding boxes are extended in
+> the appropriate dimension to become square windows, so that
+> resizing them to 32-by-32 pixels does not introduce aspect
+> ratio distortions. Nevertheless this preprocessing introduces
+> some distracting digits to the sides of the digit of interest.
+
+!!! note
+
+    For non-commercial use only
+
+## Contents
+
+```@contents
+Pages = ["SVHN2.md"]
+Depth = 3
+```
+
+## Overview
+
+The `MLDatasets.SVHN2` sub-module provides a programmatic
+interface to download, load, and work with the SVHN2 dataset of
+handwritten digits.
+
+```julia
+using MLDatasets
+
+# load full training set
+train_x, train_y = SVHN2.traindata()
+
+# load full test set
+test_x,  test_y  = SVHN2.testdata()
+
+# load additional train set
+extra_x, extra_y = SVHN2.extradata()
+```
+
+The provided functions also allow for optional arguments, such as
+the directory `dir` where the dataset is located, or the specific
+observation `indices` that one wants to work with. For more
+information on the interface take a look at the documentation
+(e.g. `?SVHN2.traindata`).
+
+Function | Description
+---------|-------------
+[`download([dir])`](@ref SVHN2.download) | Trigger interactive download of the dataset
+[`classnames()`](@ref SVHN2.classnames) | Return the class names as a vector of strings
+[`traindata([T], [indices]; [dir])`](@ref SVHN2.traindata) | Load images and labels of the training data
+[`testdata([T], [indices]; [dir])`](@ref SVHN2.testdata) | Load images and labels of the test data
+[`extradata([T], [indices]; [dir])`](@ref SVHN2.extradata) | Load images and labels of the extra training data
+
+This module also provides utility functions to make working with
+the SVHN (format 2) dataset in Julia more convenient.
+
+Function | Description
+---------|-------------
+[`convert2features(array)`](@ref SVHN2.convert2features) | Convert the SVHN tensor to a flat feature matrix
+[`convert2image(array)`](@ref SVHN2.convert2image) | Convert the SVHN tensor/matrix to a colorant array
+
+You can use the function
+[`convert2features`](@ref SVHN2.convert2features) to convert
+the given SVHN tensor to a feature matrix (or feature vector
+in the case of a single image). The purpose of this function is
+to drop the spatial dimensions such that traditional ML
+algorithms can process the dataset.
+
+```julia
+julia> SVHN2.convert2features(SVHN2.traindata()[1]) # full training data
+3072×73257 Array{N0f8,2}:
+[...]
+```
+
+To visualize an image or a prediction we provide the function
+[`convert2image`](@ref SVHN2.convert2image) to convert the
+given SVHN2 horizontal-major tensor (or feature matrix) to a
+vertical-major `Colorant` array.
+
+```julia
+julia> SVHN2.convert2image(SVHN2.traindata(1)[1]) # first training image
+32×32 Array{RGB{N0f8},2}:
+[...]
+```
+
+## API Documentation
+
+```@docs
+SVHN2
+```
+
+### Trainingset
+
+```@docs
+SVHN2.traindata
+```
+
+### Testset
+
+```@docs
+SVHN2.testdata
+```
+
+### Extraset
+
+```@docs
+SVHN2.extradata
+```
+
+### Utilities
+
+```@docs
+SVHN2.download
+SVHN2.classnames
+SVHN2.convert2features
+SVHN2.convert2image
+```
+
+## References
+
+- **Authors**: Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
+
+- **Website**: http://ufldl.stanford.edu/housenumbers
+
+- **[Netzer et al., 2011]** Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng. "Reading Digits in Natural Images with Unsupervised Feature Learning" NIPS Workshop on Deep Learning and Unsupervised Feature Learning 2011

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,6 +73,9 @@ Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels`
 [**FashionMNIST**](@ref FashionMNIST) | 10 | 28x28x60000 | 60000 | 28x28x10000 | 10000
 [**CIFAR-10**](@ref CIFAR10) | 10 | 32x32x3x50000 | 50000 | 32x32x3x10000 | 10000
 [**CIFAR-100**](@ref CIFAR100) | 100 (20) | 32x32x3x50000 | 50000 (x2) | 32x32x3x10000 | 10000 (x2)
+[**SVHN-2**](@ref SVHN2) (*) | 10 | 32x32x3x73257 | 73257 | 32x32x3x26032 | 26032
+
+(*) Note that the SVHN-2 dataset provides an additional 531131 observations aside from the training- and testset
 
 ### Language Modeling
 

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -16,6 +16,7 @@ include("CIFAR10/CIFAR10.jl")
 include("CIFAR100/CIFAR100.jl")
 include("MNIST/MNIST.jl")
 include("FashionMNIST/FashionMNIST.jl")
+include("SVHN2/SVHN2.jl")
 include("PTBLM/PTBLM.jl")
 include("UD_English/UD_English.jl")
 

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -3,8 +3,8 @@ export SVHN2
 """
 The Street View House Numbers (SVHN) Dataset
 
-Authors: Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
-Website: http://ufldl.stanford.edu/housenumbers
+- Authors: Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
+- Website: http://ufldl.stanford.edu/housenumbers
 
 SVHN was obtained from house numbers in Google Street View
 images. As such they are quite diverse in terms of orientation
@@ -17,14 +17,15 @@ additional to use as extra training data.
 
 ## Interface
 
-- [SVHN2.traindata](@ref)
-- [SVHN2.testdata](@ref)
-- [SVHN2.extradata](@ref)
+- [`SVHN2.traindata`](@ref)
+- [`SVHN2.testdata`](@ref)
+- [`SVHN2.extradata`](@ref)
 
 ## Utilities
 
-- [SVHN2.convert2features](@ref)
-- [SVHN2.convert2image](@ref)
+- [`SVHN2.classnames`](@ref)
+- [`SVHN2.convert2features`](@ref)
+- [`SVHN2.convert2image`](@ref)
 """
 module SVHN2
     using DataDeps
@@ -54,6 +55,19 @@ module SVHN2
     const EXTRADATA = "extra_32x32.mat"
     const CLASSES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
 
+    """
+        download([dir]; [i_accept_the_terms_of_use])
+
+    Trigger the (interactive) download of the full dataset into
+    "<`dir`>/$DEPNAME". If no `dir` is provided the dataset will
+    be downloaded into "~/.julia/datadeps/$DEPNAME".
+
+    This function will display an interactive dialog unless
+    either the keyword parameter `i_accept_the_terms_of_use` or
+    the environment variable `DATADEPS_ALWAY_ACCEPT` is set to
+    `true`. Note that using the data responsibly and respecting
+    copyright/terms-of-use remains your responsibility.
+    """
     download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
 
     include("interface.jl")
@@ -87,6 +101,7 @@ module SVHN2
             dataset.
             """,
             "http://ufldl.stanford.edu/housenumbers/" .* [TRAINDATA, TESTDATA, EXTRADATA],
+            "2fa3b0b79baf39de36ed7579e6947760e6241f4c52b6b406cabc44d654c13a50"
         )
     end
 end

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -68,8 +68,8 @@ module SVHN2
         download([dir]; [i_accept_the_terms_of_use])
 
     Trigger the (interactive) download of the full dataset into
-    "<`dir`>/$DEPNAME". If no `dir` is provided the dataset will
-    be downloaded into "~/.julia/datadeps/$DEPNAME".
+    "`dir`". If no `dir` is provided the dataset will be
+    downloaded into "~/.julia/datadeps/$DEPNAME".
 
     This function will display an interactive dialog unless
     either the keyword parameter `i_accept_the_terms_of_use` or

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -1,0 +1,92 @@
+export SVHN2
+
+"""
+The Street View House Numbers (SVHN) Dataset
+
+Authors: Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
+Website: http://ufldl.stanford.edu/housenumbers
+
+SVHN was obtained from house numbers in Google Street View
+images. As such they are quite diverse in terms of orientation
+and image background. Similar to MNIST, SVHN has 10 classes (the
+digits 0-9), but unlike MNIST there is more data and the images
+are a little bigger (32x32 instead of 28x28) with an additional
+RGB color channel. The dataset is split up into three subsets:
+73257 digits for training, 26032 digits for testing, and 531131
+additional to use as extra training data.
+
+## Interface
+
+- [SVHN2.traindata](@ref)
+- [SVHN2.testdata](@ref)
+- [SVHN2.extradata](@ref)
+
+## Utilities
+
+- [SVHN2.convert2features](@ref)
+- [SVHN2.convert2image](@ref)
+"""
+module SVHN2
+    using DataDeps
+    using MAT
+    using ImageCore
+    using ColorTypes
+    using FixedPointNumbers
+    using ..bytes_to_type
+    using ..datafile
+    using ..download_dep
+    using ..download_docstring
+
+    export
+
+        traindata,
+        testdata,
+        extradata,
+
+        convert2image,
+        convert2features,
+
+        download
+
+    const DEPNAME = "SVHN2"
+    const TRAINDATA = "train_32x32.mat"
+    const TESTDATA  = "test_32x32.mat"
+    const EXTRADATA = "extra_32x32.mat"
+    const CLASSES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+
+    download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
+
+    include("interface.jl")
+    include("utils.jl")
+
+    function __init__()
+        RegisterDataDep(
+            DEPNAME,
+            """
+            Dataset: The Street View House Numbers (SVHN) Dataset
+            Authors: Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
+            Website: http://ufldl.stanford.edu/housenumbers
+            Format: Cropped Digits (Format 2 on the website)
+            Note: for non-commercial use only
+
+            [Netzer et al., 2011]
+                Yuval Netzer, Tao Wang, Adam Coates, Alessandro Bissacco, Bo Wu, Andrew Y. Ng
+                "Reading Digits in Natural Images with Unsupervised Feature Learning"
+                NIPS Workshop on Deep Learning and Unsupervised Feature Learning 2011
+
+            The dataset is split up into three subsets: 73257
+            digits for training, 26032 digits for testing, and
+            531131 additional to use as extra training data.
+
+            The files are available for download at the official
+            website linked above. Note that using the data
+            responsibly and respecting copyright remains your
+            responsibility. For example the website mentions that
+            the data is for non-commercial use only. Please read
+            the website to make sure you want to download the
+            dataset.
+            """,
+            "http://ufldl.stanford.edu/housenumbers/" .* [TRAINDATA, TESTDATA, EXTRADATA],
+        )
+    end
+end

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -17,12 +17,13 @@ additional to use as extra training data.
 
 ## Interface
 
-- [`SVHN2.traindata`](@ref)
-- [`SVHN2.testdata`](@ref)
-- [`SVHN2.extradata`](@ref)
+- [`SVHN2.traintensor`](@ref), [`SVHN2.trainlabels`](@ref), [`SVHN2.traindata`](@ref)
+- [`SVHN2.testtensor`](@ref), [`SVHN2.testlabels`](@ref), [`SVHN2.testdata`](@ref)
+- [`SVHN2.extratensor`](@ref), [`SVHN2.extralabels`](@ref), [`SVHN2.extradata`](@ref)
 
 ## Utilities
 
+- [`SVHN2.download`](@ref)
 - [`SVHN2.classnames`](@ref)
 - [`SVHN2.convert2features`](@ref)
 - [`SVHN2.convert2image`](@ref)
@@ -39,6 +40,14 @@ module SVHN2
     using ..download_docstring
 
     export
+
+        traintensor,
+        testtensor,
+        extratensor,
+
+        trainlabels,
+        testlabels,
+        extralabels,
 
         traindata,
         testdata,

--- a/src/SVHN2/interface.jl
+++ b/src/SVHN2/interface.jl
@@ -1,0 +1,150 @@
+"""
+    classnames() -> Vector{Int}
+
+Return the 10 digits for the SVHN classes as a vector of integers.
+"""
+classnames() = CLASSES
+
+"""
+    traindata([T = N0f8], [indices]; [dir]) -> images, labels
+
+Returns the SVHN **trainset** corresponding to the given
+`indices` as a two-element tuple. If `indices` is omitted the
+full trainset is returned. The first element of the return values
+will be the images as a multi-dimensional array, and the second
+element the corresponding labels as integers.
+
+The image(s) is/are returned in the native vertical-major memory
+layout as a single numeric array of eltype `T`. If `T <:
+Integer`, then all values will be within `0` and `255`, otherwise
+the values are scaled to be between `0` and `1`. You can use the
+utility function [`convert2image`](@ref) to convert an SVHN array
+into a Julia image with the appropriate `RGB` eltype. The integer
+values of the labels correspond 1-to-1 the digit that they
+represent with the exception of 0 which is encoded as `10`.
+
+Note that because of the nature of how the dataset is stored on
+disk, `SVHN2.traindata` will always load the full trainset,
+regardless of which observations are requested. In the case
+`indices` are provided by the user, it will simply result in a
+sub-setting. This option is just provided for convenience.
+
+```julia
+train_x, train_y = SVHN2.traindata() # full dataset
+train_x, train_y = SVHN2.traindata(2) # only second observation
+train_x, train_y = SVHN2.traindata(dir="./SVHN") # custom folder
+```
+
+$(download_docstring("SVHN", DEPNAME))
+"""
+function traindata(args...; dir = nothing)
+    traindata(N0f8, args...; dir = dir)
+end
+
+function traindata(::Type{T}; dir = nothing) where T
+    path = datafile(DEPNAME, TRAINDATA, dir)
+    vars = matread(path)
+    images, labels = vars["X"], vars["y"]
+    bytes_to_type(T, images), Vector{Int}(vec(labels))
+end
+
+function traindata(::Type{T}, indices; dir = nothing) where T
+    images, labels = traindata(T, dir = dir)
+    images[:,:,:,indices], labels[indices]
+end
+
+"""
+    testdata([T = N0f8], [indices]; [dir]) -> images, labels
+
+Returns the SVHN **testset** corresponding to the given
+`indices` as a two-element tuple. If `indices` is omitted the
+full testset is returned. The first element of the return
+values will be the images as a multi-dimensional array, and the
+second element the corresponding labels as integers.
+
+The image(s) is/are returned in the native vertical-major memory
+layout as a single numeric array of eltype `T`. If `T <:
+Integer`, then all values will be within `0` and `255`, otherwise
+the values are scaled to be between `0` and `1`. You can use the
+utility function [`convert2image`](@ref) to convert an SVHN array
+into a Julia image with the appropriate `RGB` eltype. The integer
+values of the labels correspond 1-to-1 the digit that they
+represent with the exception of 0 which is encoded as `10`.
+
+Note that because of the nature of how the dataset is stored on
+disk, `SVHN2.testdata` will always load the full testset,
+regardless of which observations are requested. In the case
+`indices` are provided by the user, it will simply result in a
+sub-setting. This option is just provided for convenience.
+
+```julia
+test_x, test_y = SVHN2.testdata() # full dataset
+test_x, test_y = SVHN2.testdata(2) # only second observation
+test_x, test_y = SVHN2.testdata(dir="./SVHN") # custom folder
+```
+
+$(download_docstring("SVHN", DEPNAME))
+"""
+function testdata(args...; dir = nothing)
+    testdata(N0f8, args...; dir = dir)
+end
+
+function testdata(::Type{T}; dir = nothing) where T
+    path = datafile(DEPNAME, TESTDATA, dir)
+    vars = matread(path)
+    images, labels = vars["X"], vars["y"]
+    bytes_to_type(T, images), Vector{Int}(vec(labels))
+end
+
+function testdata(::Type{T}, indices; dir = nothing) where T
+    images, labels = testdata(T, dir = dir)
+    images[:,:,:,indices], labels[indices]
+end
+
+"""
+    extradata([T = N0f8], [indices]; [dir]) -> images, labels
+
+Returns the SVHN **extra trainset** corresponding to the given
+`indices` as a two-element tuple. If `indices` is omitted the
+full dataset is returned. The first element of the return values
+will be the images as a multi-dimensional array, and the second
+element the corresponding labels as integers.
+
+The image(s) is/are returned in the native vertical-major memory
+layout as a single numeric array of eltype `T`. If `T <:
+Integer`, then all values will be within `0` and `255`, otherwise
+the values are scaled to be between `0` and `1`. You can use the
+utility function [`convert2image`](@ref) to convert an SVHN array
+into a Julia image with the appropriate `RGB` eltype. The integer
+values of the labels correspond 1-to-1 the digit that they
+represent with the exception of 0 which is encoded as `10`.
+
+Note that because of the nature of how the dataset is stored on
+disk, `SVHN2.extradata` will always load the full extra trainset,
+regardless of which observations are requested. In the case
+`indices` are provided by the user, it will simply result in a
+sub-setting. This option is just provided for convenience.
+
+```julia
+extra_x, extra_y = SVHN2.extradata() # full dataset
+extra_x, extra_y = SVHN2.extradata(2) # only second observation
+extra_x, extra_y = SVHN2.extradata(dir="./SVHN") # custom folder
+```
+
+$(download_docstring("SVHN", DEPNAME))
+"""
+function extradata(args...; dir = nothing)
+    extradata(N0f8, args...; dir = dir)
+end
+
+function extradata(::Type{T}; dir = nothing) where T
+    path = datafile(DEPNAME, EXTRADATA, dir)
+    vars = matread(path)
+    images, labels = vars["X"], vars["y"]
+    bytes_to_type(T, images), Vector{Int}(vec(labels))
+end
+
+function extradata(::Type{T}, indices; dir = nothing) where T
+    images, labels = extradata(T, dir = dir)
+    images[:,:,:,indices], labels[indices]
+end

--- a/src/SVHN2/interface.jl
+++ b/src/SVHN2/interface.jl
@@ -35,7 +35,7 @@ train_x, train_y = SVHN2.traindata(2) # only second observation
 train_x, train_y = SVHN2.traindata(dir="./SVHN") # custom folder
 ```
 
-$(download_docstring("SVHN", DEPNAME))
+$(download_docstring("SVHN2", DEPNAME))
 """
 function traindata(args...; dir = nothing)
     traindata(N0f8, args...; dir = dir)
@@ -83,7 +83,7 @@ test_x, test_y = SVHN2.testdata(2) # only second observation
 test_x, test_y = SVHN2.testdata(dir="./SVHN") # custom folder
 ```
 
-$(download_docstring("SVHN", DEPNAME))
+$(download_docstring("SVHN2", DEPNAME))
 """
 function testdata(args...; dir = nothing)
     testdata(N0f8, args...; dir = dir)
@@ -131,7 +131,7 @@ extra_x, extra_y = SVHN2.extradata(2) # only second observation
 extra_x, extra_y = SVHN2.extradata(dir="./SVHN") # custom folder
 ```
 
-$(download_docstring("SVHN", DEPNAME))
+$(download_docstring("SVHN2", DEPNAME))
 """
 function extradata(args...; dir = nothing)
     extradata(N0f8, args...; dir = dir)

--- a/src/SVHN2/interface.jl
+++ b/src/SVHN2/interface.jl
@@ -75,12 +75,12 @@ for (FUN, PATH, COUNT, DESC) in (
 
         function ($FUN)(::Type{T}; dir = nothing) where T
             path = datafile(DEPNAME, $PATH, dir)
-            images = matopen(io->read(io, "X"), path)
+            images = matopen(io->read(io, "X"), path)::Array{UInt8,4}
             bytes_to_type(T, images)
         end
 
         function ($FUN)(::Type{T}, indices; dir = nothing) where T
-            images = ($FUN)(T, dir = dir)
+            images = ($FUN)(T, dir = dir)::Array{T,4}
             images[:,:,:,indices]
         end
     end
@@ -124,11 +124,11 @@ for (FUN, PATH, COUNT, DESC) in (
         function ($FUN)(; dir = nothing)
             path = datafile(DEPNAME, $PATH, dir)
             labels = matopen(io->read(io, "y"), path)
-            Vector{Int}(vec(labels))
+            Vector{Int}(vec(labels))::Vector{Int}
         end
 
         function ($FUN)(indices; dir = nothing)
-            labels = ($FUN)(dir = dir)
+            labels = ($FUN)(dir = dir)::Vector{Int}
             labels[indices]
         end
     end
@@ -184,8 +184,9 @@ for (FUN, PATH, DESC) in (
         function ($FUN)(::Type{T}; dir = nothing) where T
             path = datafile(DEPNAME, $PATH, dir)
             vars = matread(path)
-            images, labels = vars["X"], vars["y"]
-            bytes_to_type(T, images), Vector{Int}(vec(labels))
+            images = vars["X"]::Array{UInt8,4}
+            labels = vars["y"]
+            bytes_to_type(T, images), Vector{Int}(vec(labels))::Vector{Int}
         end
 
         function ($FUN)(::Type{T}, indices; dir = nothing) where T

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -11,7 +11,7 @@ julia> SVHN2.convert2features(SVHN2.traindata(Float32)[1]) # full training data
 3072×50000 Array{Float32,2}:
 [...]
 
-julia> SVHN2.convert2features(SVHN2.traindata(Float32)[1][:,:,:,1]) # first observation
+julia> SVHN2.convert2features(SVHN2.traindata(Float32,1)[1]) # first observation
 3072-element Array{Float32,1}:
 [...]
 ```
@@ -45,7 +45,7 @@ julia> SVHN2.convert2image(SVHN2.traindata()[1]) # full training dataset
 32×32×50000 Array{RGB{N0f8},3}:
 [...]
 
-julia> SVHN2.convert2image(SVHN2.traindata()[1][:,:,:,1]) # first training image
+julia> SVHN2.convert2image(SVHN2.traindata(1)[1]) # first training image
 32×32 Array{RGB{N0f8},2}:
 [...]
 ```

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -29,10 +29,10 @@ function convert2features(array::AbstractArray{<:Number,4})
 end
 
 convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(channelview(array), (3,1,2)))
+    convert2features(permutedims(channelview(array), (2,3,1)))
 
 convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(channelview(array), (3,1,2,4)))
+    convert2features(permutedims(channelview(array), (2,3,1,4)))
 
 """
     convert2image(array) -> Array{RGB}

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -1,0 +1,81 @@
+"""
+    convert2features(array)
+
+Convert the given SVHN tensor to a feature matrix (or feature
+vector in the case of a single image). The purpose of this
+function is to drop the spatial dimensions such that traditional
+ML algorithms can process the dataset.
+
+```julia
+julia> SVHN2.convert2features(SVHN2.traindata(Float32)[1]) # full training data
+3072×50000 Array{Float32,2}:
+[...]
+
+julia> SVHN2.convert2features(SVHN2.traindata(Float32)[1][:,:,:,1]) # first observation
+3072-element Array{Float32,1}:
+[...]
+```
+"""
+function convert2features(array::AbstractArray{<:Number,3})
+    nrows, ncols, nchan = size(array)
+    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
+    vec(array)
+end
+
+function convert2features(array::AbstractArray{<:Number,4})
+    nrows, ncols, nchan, nimages = size(array)
+    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
+    reshape(array, (nrows * ncols * nchan, nimages))
+end
+
+convert2features(array::AbstractArray{<:RGB,2}) =
+    convert2features(permutedims(channelview(array), (3,1,2)))
+
+convert2features(array::AbstractArray{<:RGB,3}) =
+    convert2features(permutedims(channelview(array), (3,1,2,4)))
+
+"""
+    convert2image(array) -> Array{RGB}
+
+Convert the given SVHN tensor (or feature vector/matrix) to a
+`RGB` array.
+
+```julia
+julia> SVHN2.convert2image(SVHN2.traindata()[1]) # full training dataset
+32×32×50000 Array{RGB{N0f8},3}:
+[...]
+
+julia> SVHN2.convert2image(SVHN2.traindata()[1][:,:,:,1]) # first training image
+32×32 Array{RGB{N0f8},2}:
+[...]
+```
+"""
+function convert2image(array::AbstractVector{<:Number})
+    @assert length(array) % 3072 == 0
+    if length(array) == 3072
+        convert2image(reshape(array, 32, 32, 3))
+    else
+        n = Int(length(array) / 3072)
+        convert2image(reshape(array, 32, 32, 3, n))
+    end
+end
+
+function convert2image(array::AbstractMatrix{<:Number})
+    @assert size(array, 1) == 3072
+    convert2image(reshape(array, 32, 32, 3, size(array, 2)))
+end
+
+function convert2image(array::AbstractArray{<:Number,3})
+    nrows, ncols, nchan = size(array)
+    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
+    colorview(RGB, permutedims(_norm_array(array), (3,1,2)))
+end
+
+function convert2image(array::AbstractArray{<:Number,4})
+    nrows, ncols, nchan, nimages = size(array)
+    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
+    colorview(RGB, permutedims(_norm_array(array), (3,1,2,4)))
+end
+
+_norm_array(array::AbstractArray) = array
+_norm_array(array::AbstractArray{<:Integer}) = reinterpret(N0f8, convert(Array{UInt8}, array))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ tests = [
     "tst_cifar100.jl",
     "tst_mnist.jl",
     "tst_fashion_mnist.jl",
+    "tst_svhn2.jl",
 ]
 
 for t in tests

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -57,6 +57,200 @@ else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"SVHN2"
     end
+
+    @testset "Images" begin
+        X_train = @inferred SVHN2.traintensor()
+        X_test  = @inferred SVHN2.testtensor()
+        X_extra = @inferred SVHN2.extratensor()
+        @test size(X_train, 4) == 73_257
+        @test size(X_test,  4) == 26_032
+        @test size(X_extra, 4) == 531_131
+
+        # Sanity check that the first trainimage is not the
+        # first testimage nor extra image
+        @test X_train[:,:,:,1] != X_test[:,:,:,1]
+        @test X_train[:,:,:,1] != X_extra[:,:,:,1]
+        @test X_test[:,:,:,1]  != X_extra[:,:,:,1]
+        # Make sure other integer types work as indicies
+        @test SVHN2.testtensor(0xBAE) == SVHN2.testtensor(2990)
+
+        @test reinterpret(UInt8, X_train)[11:13, 12:14, 1, 1] == [
+            0x5a  0x5c  0x5b
+            0x5c  0x5b  0x5d
+            0x5d  0x57  0x59
+        ]
+        @test reinterpret(UInt8, X_test)[11:13, 12:14, 1, 1] == [
+            0x28  0x2f  0x33
+            0x2e  0x38  0x3b
+            0x2d  0x37  0x3b
+        ]
+        @test reinterpret(UInt8, X_extra)[11:13, 12:14, 1, 1] == [
+            0x51  0x51  0x50
+            0x53  0x4e  0x4c
+            0x52  0x4c  0x49
+        ]
+
+        # These tests check if the functions return internaly
+        # consistent results for different parameters (e.g. index
+        # as int or as vector). That means no matter how you
+        # specify an index, you will always get the same result
+        # for a specific index.
+        for (image_fun, T, nimages) in (
+                (SVHN2.testtensor, UInt8,   26_032),
+                (SVHN2.testtensor, Int,     26_032),
+                (SVHN2.testtensor, Float64, 26_032),
+                (SVHN2.testtensor, Float32, 26_032),
+                (SVHN2.testtensor, N0f8,    26_032),
+            )
+            @testset "$image_fun with T=$T" begin
+                # whole image set
+                A = @inferred image_fun(T)
+                @test typeof(A) <: Array{T,4}
+                @test size(A) == (32,32,3,nimages)
+
+                @test_throws BoundsError image_fun(T,-1)
+                @test_throws BoundsError image_fun(T,0)
+                @test_throws BoundsError image_fun(T,nimages+1)
+
+                @testset "load single images" begin
+                    # Sample a few random images to compare
+                    for i = rand(1:nimages, 3)
+                        A_i = @inferred image_fun(T,i)
+                        @test typeof(A_i) <: Array{T,3}
+                        @test size(A_i) == (32,32,3)
+                        @test A_i == A[:,:,:,i]
+                    end
+                end
+
+                @testset "load multiple images" begin
+                    A_5_10 = @inferred image_fun(T,5:10)
+                    @test typeof(A_5_10) <: Array{T,4}
+                    @test size(A_5_10) == (32,32,3,6)
+                    for i = 1:6
+                        @test A_5_10[:,:,:,i] == A[:,:,:,i+4]
+                    end
+
+                    # also test edge cases `1`, `nimages`
+                    indices = [10,3,9,1,nimages]
+                    A_vec   = image_fun(T,indices)
+                    A_vec_f = image_fun(T,Vector{Int32}(indices))
+                    @test typeof(A_vec)   <: Array{T,4}
+                    @test typeof(A_vec_f) <: Array{T,4}
+                    @test size(A_vec)   == (32,32,3,5)
+                    @test size(A_vec_f) == (32,32,3,5)
+                    for i in 1:5
+                        @test A_vec[:,:,:,i] == A[:,:,:,indices[i]]
+                        @test A_vec[:,:,:,i] == A_vec_f[:,:,:,i]
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "Labels" begin
+        # Sanity check that the first trainlabel is not also
+        # the first testlabel
+        @test SVHN2.trainlabels(1) != SVHN2.testlabels(1)
+        @test SVHN2.trainlabels(1) != SVHN2.extralabels(1)
+        @test SVHN2.testlabels(1) != SVHN2.extralabels(1)
+
+        # Check a few hand picked examples. I looked at both the
+        # pictures and the native output to make sure these
+        # values are correspond to the image at the same index.
+        @test SVHN2.trainlabels(1) === 1
+        @test SVHN2.trainlabels(2) === 9
+        @test SVHN2.trainlabels(1337) === 2
+        @test SVHN2.trainlabels(0xCAF) === 3
+        @test SVHN2.trainlabels(73_257) === 9
+        @test SVHN2.testlabels(1) === 5
+        @test SVHN2.testlabels(4) === 10
+        @test SVHN2.testlabels(0xDAD) === 4
+        @test SVHN2.testlabels(26_032) === 7
+        @test SVHN2.extralabels(1) === 4
+        @test SVHN2.extralabels(3) === 8
+        @test SVHN2.extralabels(531_131) === 4
+
+        # These tests check if the functions return internaly
+        # consistent results for different parameters (e.g. index
+        # as int or as vector). That means no matter how you
+        # specify an index, you will always get the same result
+        # for a specific index.
+        # -- However, technically these tests do not check if
+        #    these are the actual SVHN labels of that index!
+        for (label_fun, nlabels) in
+                    ((SVHN2.trainlabels, 73_257),
+                     (SVHN2.testlabels,  26_032),
+                     (SVHN2.extralabels, 531_131))
+            @testset "$label_fun" begin
+                # whole label set
+                A = @inferred label_fun()
+                @test typeof(A) <: Vector{Int64}
+                @test size(A) == (nlabels,)
+
+                @testset "load single label" begin
+                    # Sample a few random labels to compare
+                    for i = rand(1:nlabels, 10)
+                        A_i = @inferred label_fun(i)
+                        @test typeof(A_i) <: Int64
+                        @test A_i == A[i]
+                    end
+                end
+
+                @testset "load multiple labels" begin
+                    A_5_10 = @inferred label_fun(5:10)
+                    @test typeof(A_5_10) <: Vector{Int64}
+                    @test size(A_5_10) == (6,)
+                    for i = 1:6
+                        @test A_5_10[i] == A[i+4]
+                    end
+
+                    # also test edge cases `1`, `nlabels`
+                    indices = [10,3,9,1,nlabels]
+                    A_vec   = @inferred label_fun(indices)
+                    A_vec_f = @inferred label_fun(Vector{Int32}(indices))
+                    @test typeof(A_vec)   <: Vector{Int64}
+                    @test typeof(A_vec_f) <: Vector{Int64}
+                    @test size(A_vec)   == (5,)
+                    @test size(A_vec_f) == (5,)
+                    for i in 1:5
+                        @test A_vec[i] == A[indices[i]]
+                        @test A_vec[i] == A_vec_f[i]
+                    end
+                end
+            end
+        end
+    end
+
+    # Check against the already tested tensor and labels functions
+    @testset "Data" begin
+        for (data_fun, feature_fun, label_fun, nobs) in
+                 ((SVHN2.testdata,  SVHN2.testtensor,  SVHN2.testlabels,  26_032),)
+            @testset "check $data_fun against $feature_fun and $label_fun" begin
+                data, labels = @inferred data_fun()
+                @test data == @inferred feature_fun()
+                @test labels == @inferred label_fun()
+
+                for i = rand(1:nobs, 10)
+                    d_i, l_i = @inferred data_fun(i)
+                    @test d_i == @inferred feature_fun(i)
+                    @test l_i == @inferred label_fun(i)
+                end
+
+                data, labels = @inferred data_fun(5:10)
+                @test data == @inferred feature_fun(5:10)
+                @test labels == @inferred label_fun(5:10)
+
+                data, labels = @inferred data_fun(Int, 5:10)
+                @test data == @inferred feature_fun(Int, 5:10)
+                @test labels == @inferred label_fun(5:10)
+
+                indices = [10,3,9,1,nobs]
+                data, labels = @inferred data_fun(indices)
+                @test data == @inferred feature_fun(indices)
+                @test labels == @inferred label_fun(indices)
+            end
+        end
+    end
 end
 
 end

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -1,0 +1,62 @@
+module SVHN2_Tests
+using Base.Test
+using ColorTypes
+using ImageCore
+using FixedPointNumbers
+using MLDatasets
+using DataDeps
+
+@testset "Constants" begin
+    @test SVHN2.classnames() isa Vector{Int}
+    @test SVHN2.classnames() == [1,2,3,4,5,6,7,8,9,0]
+    @test length(SVHN2.classnames()) == 10
+    @test length(unique(SVHN2.classnames())) == 10
+
+    @test DataDeps.registry["SVHN2"] isa DataDeps.DataDep
+end
+
+@testset "convert2features" begin
+    data = rand(32,32,3)
+    ref = vec(data)
+    @test @inferred(SVHN2.convert2features(data)) == ref
+    @test @inferred(SVHN2.convert2features(SVHN2.convert2image(data))) == ref
+
+    data = rand(32,32,3,2)
+    ref = reshape(data, (32*32*3, 2))
+    @test @inferred(SVHN2.convert2features(data)) == ref
+    @test @inferred(SVHN2.convert2features(SVHN2.convert2image(data))) == ref
+end
+
+@testset "convert2images" begin
+    @test_throws AssertionError SVHN2.convert2image(rand(100))
+    @test_throws AssertionError SVHN2.convert2image(rand(228,1))
+    @test_throws AssertionError SVHN2.convert2image(rand(32,32,4))
+
+    data = rand(N0f8,32,32,3)
+    A = @inferred SVHN2.convert2image(data)
+    @test size(A) == (32,32)
+    @test eltype(A) == RGB{N0f8}
+    @test SVHN2.convert2image(vec(data)) == A
+    @test permutedims(channelview(A), (2,3,1)) == data
+    @test SVHN2.convert2image(reinterpret(UInt8, data)) == A
+
+    data = rand(N0f8,32,32,3,2)
+    A = @inferred SVHN2.convert2image(data)
+    @test size(A) == (32,32,2)
+    @test eltype(A) == RGB{N0f8}
+    @test SVHN2.convert2image(vec(data)) == A
+    @test SVHN2.convert2image(SVHN2.convert2features(data)) == A
+    @test SVHN2.convert2image(reinterpret(UInt8, data)) == A
+end
+
+# NOT executed on CI. only executed locally.
+# This involves dataset download etc.
+if parse(Bool, get(ENV, "CI", "false"))
+    info("CI detected: skipping dataset download")
+else
+    data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+        datadep"SVHN2"
+    end
+end
+
+end


### PR DESCRIPTION
I am working on integrating the [street view house numbers](http://ufldl.stanford.edu/housenumbers/) dataset. 

A big downside is that the data is provided in `.mat` format at the official website. This means that we would need to add a dependency on `MAT.jl` which requires `HDF5.jl`. Aside from the binary dependency it is also less convenient to work with. For starters one needs to read the whole file and can just cherry pick specific observations. 