### PR TITLE
fix RegisterDataDep deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,6 @@ julia 0.6
 ImageCore 0.1.2
 FixedPointNumbers 0.3
 ColorTypes 0.4
-DataDeps
+DataDeps 0.3
 GZip
 BinDeps

--- a/src/CIFAR10/CIFAR10.jl
+++ b/src/CIFAR10/CIFAR10.jl
@@ -57,7 +57,7 @@ module CIFAR10
     include("utils.jl")
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: The CIFAR-10 dataset
@@ -88,6 +88,6 @@ module CIFAR10
             "https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz",
             "c4a38c50a1bc5f3a1c5537f2155ab9d68f9f25eb1ed8d9ddda3db29a59bca1dd",
             post_fetch_method = file -> (run(BinDeps.unpack_cmd(file,dirname(file), ".gz", ".tar")); rm(file))
-        )
+        ))
     end
 end

--- a/src/CIFAR100/CIFAR100.jl
+++ b/src/CIFAR100/CIFAR100.jl
@@ -44,7 +44,7 @@ module CIFAR100
     include("interface.jl")
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: The CIFAR-100 dataset
@@ -80,6 +80,6 @@ module CIFAR100
             "https://www.cs.toronto.edu/~kriz/cifar-100-binary.tar.gz",
             "58a81ae192c23a4be8b1804d68e518ed807d710a4eb253b1f2a199162a40d8ec",
             post_fetch_method = file -> (run(BinDeps.unpack_cmd(file,dirname(file), ".gz", ".tar")); rm(file))
-        )
+        ))
     end
 end

--- a/src/FashionMNIST/FashionMNIST.jl
+++ b/src/FashionMNIST/FashionMNIST.jl
@@ -53,7 +53,7 @@ module FashionMNIST
     include("interface.jl")
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: Fashion-MNIST
@@ -73,6 +73,6 @@ module FashionMNIST
             """,
             "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/" .* [TRAINIMAGES, TRAINLABELS, TESTIMAGES, TESTLABELS],
             "c916b6e00d3083643332b70f3c5c3543d3941334b802e252976893969ee6af67",
-        )
+        ))
     end
 end

--- a/src/MNIST/MNIST.jl
+++ b/src/MNIST/MNIST.jl
@@ -39,7 +39,7 @@ module MNIST
     include("utils.jl")
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: THE MNIST DATABASE of handwritten digits
@@ -61,6 +61,6 @@ module MNIST
             """,
             "http://yann.lecun.com/exdb/mnist/" .* [TRAINIMAGES, TRAINLABELS, TESTIMAGES, TESTLABELS],
             "0bb1d5775d852fc5bb32c76ca15a7eb4e9a3b1514a2493f7edfcf49b639d7975",
-        )
+        ))
     end
 end

--- a/src/PTBLM/PTBLM.jl
+++ b/src/PTBLM/PTBLM.jl
@@ -49,7 +49,7 @@ module PTBLM
     end
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: Penn Treebank sentences for language modeling
@@ -76,6 +76,6 @@ module PTBLM
             """,
             "https://raw.githubusercontent.com/tomsercu/lstm/master/data/" .* [TRAINFILE, TESTFILE],
             "218f4e6c7288bb5efeb03cc4cb8ae9c04ecd8462ebfba8e13e3549fab69dc25f",
-        )
+        ))
     end
 end

--- a/src/UD_English/UD_English.jl
+++ b/src/UD_English/UD_English.jl
@@ -34,7 +34,7 @@ module UD_English
     end
 
     function __init__()
-        RegisterDataDep(
+        register(DataDep(
             DEPNAME,
             """
             Dataset: Universal Dependencies - English Dependency Treebank Universal Dependencies English Web Treebank
@@ -72,6 +72,6 @@ module UD_English
             """,
             "https://raw.githubusercontent.com/UniversalDependencies/UD_English/master/" .* [TRAINFILE, DEVFILE, TESTFILE],
             "2311e260488453d5ba170cfd94e58ac4bd536263ea9545c7b25f0804e87b28a2",
-        )
+        ))
     end
 end


### PR DESCRIPTION
addresses the following warning:
```julia
WARNING: RegisterDataDep(name::String, message::String, remotepath, hash=nothing; fetch_method=download, post_fetch_method=identity) is deprecated, use register(DataDep(name::String, message::String, remotepath, hash; fetch_method=fetch_method, post_fetch_method=post_fetch_method)) instead.
```