### PR TITLE
Make ImageCore and MAT optional, switch from GZip to CodecZlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
 
 after_success:
   - julia -e 'using Pkg, MLDatasets; cd(joinpath(dirname(pathof(MLDatasets)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-  - julie -e 'using Pkg; Pkg.add("Documenter"); cd(joinpath(dirname(pathof(MLDatasets)), "..")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg, MLDatasets; Pkg.add("Documenter"); cd(joinpath(dirname(pathof(MLDatasets)), "..")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,7 @@
 julia 0.7
-ImageCore 0.1.2
+Requires
 FixedPointNumbers 0.3
 ColorTypes 0.4
 DataDeps 0.3
-GZip
+CodecZlib
 BinDeps
-MAT

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,7 +30,7 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaML/MLDatasets.jl.git",
     target = "build",
-    julia = "0.6",
+    julia = "0.7",
     deps = nothing,
     make = nothing,
 )

--- a/docs/src/LICENSE.md
+++ b/docs/src/LICENSE.md
@@ -1,5 +1,6 @@
 # LICENSE
 
 ```@eval
-Markdown.parse_file(joinpath(@__DIR__, "../LICENSE"))
+using Markdown
+Markdown.parse_file(joinpath(@__DIR__, "..", "..", "LICENSE"))
 ```

--- a/src/CIFAR10/CIFAR10.jl
+++ b/src/CIFAR10/CIFAR10.jl
@@ -2,27 +2,16 @@ export CIFAR10
 module CIFAR10
     using DataDeps
     using BinDeps
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring, _colorview, _channelview
 
     export
-
         classnames,
-
-        traintensor,
-        testtensor,
-
-        trainlabels,
-        testlabels,
-
-        traindata,
-        testdata,
-
-        convert2image,
-        convert2features,
-
+        traintensor, testtensor,
+        trainlabels, testlabels,
+        traindata, testdata,
+        convert2image, convert2features,
         download
 
     const DEPNAME = "CIFAR10"
@@ -62,7 +51,7 @@ module CIFAR10
     """
     download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
 
-    include(joinpath("Reader","Reader.jl"))
+    include(joinpath("Reader", "Reader.jl"))
     include("interface.jl")
     include("utils.jl")
 

--- a/src/CIFAR10/Reader/Reader.jl
+++ b/src/CIFAR10/Reader/Reader.jl
@@ -1,54 +1,79 @@
 module Reader
 
-export
-
-    readdata!,
-    readdata
+export readdata
 
 const NROW = 32
 const NCOL = 32
 const NCHAN = 3
-const NBYTE = NROW * NCOL * NCHAN + 1 # "+ 1" for label
 const CHUNK_SIZE = 10_000
 
-function readnext!(buffer::Array{UInt8}, io::IO)
-    y = Int(read(io, UInt8))
-    read!(io, buffer)
-    buffer, y
-end
-
-function readdata!(buffer::Array{UInt8}, io::IO, index::Integer)
-    seek(io, (index - 1) * NBYTE)
-    readnext!(buffer, io)
-end
-
-function readdata(io::IO, index::Integer)
-    buffer = Array{UInt8}(undef, NROW, NCOL, NCHAN)
-    readdata!(buffer, io, index)
-end
-
-function readdata(io::IO)
-    X = Array{UInt8}(undef, NROW, NCOL, NCHAN, CHUNK_SIZE)
-    Y = Array{Int}(undef, CHUNK_SIZE)
-    buffer = Array{UInt8}(undef, NROW, NCOL, NCHAN)
-    @inbounds for index in 1:CHUNK_SIZE
-        _, ty = readnext!(buffer, io)
-        copyto!(view(X,:,:,:,index), buffer)
-        Y[index] = ty
+# Reads images and their labels at (`src_indices`-`src_offset`) positions from `io`
+# and puts them to dst_indices positions into the `images` and `labels` arrays, resp.
+# 1st, 2nd and 3rd dimensions of `images` array define width, height and N of image channels, resp.
+# `nsrc` is the total number of images available at `io`.
+# `src_indices` should be sorted in ascending order,
+# otherwise `io` will fail to go to the already read position.
+function _readdata!(io::IO,
+                    images::Array{UInt8, 4}, labels::Vector,
+                    nsrc::Integer, src_indices::AbstractVector{<:Integer},
+                    src_offset::Integer = 0, dst_indices::AbstractVector{<:Integer} = 1:size(images, 4))
+    all(ix -> 1 <= ix-src_offset <= nsrc, src_indices) ||
+        throw(ArgumentError("not all elements in parameter \"indices\" are in 1:$nsrc"))
+    img_size = map(i -> size(images, i), (1, 2, 3))
+    imagesize = prod(img_size)*sizeof(eltype(images)) + sizeof(eltype(labels))
+    if size(images, 4) == 1
+        # avoid buffer allocation for single image
+        skip(io, imagesize * (src_indices[1] - src_offset - 1))
+        labels[dst_indices[1]] = read(io, eltype(labels))
+        read!(io, images)
+    else
+        buffer = Array{UInt8}(undef, img_size)
+        pos = 0
+        @inbounds for (dst_ix, src_ix) in zip(dst_indices, src_indices)
+            nextpos = imagesize * (src_ix - src_offset - 1)
+            skip(io, nextpos - pos)
+            labels[dst_ix] = read(io, eltype(labels))
+            read!(io, buffer)
+            copyto!(view(images, :,:,:, dst_ix), buffer)
+            pos = nextpos + imagesize
+        end
     end
-    X, Y
+    return images, labels
 end
 
-function readdata(file::AbstractString, index::Integer)
+function _readdata!(file::AbstractString, images, labels, nsrc, src_indices,
+                    src_offset = 0, dst_indices::AbstractVector{<:Integer} = axes(images, 4))
     open(file, "r") do io
-        readdata(io, index)
-    end::Tuple{Array{UInt8,3},Int}
+        _readdata!(io, images, labels, nsrc, src_indices, src_offset, dst_indices)
+    end
 end
 
-function readdata(file::AbstractString)
+# Returns a tuple of `nrows`×`ncols`×`nchannels`×`length(indices)` images array
+# and `length(indices)` vector of their labels filled by `_readdata!()`
+_readdata(io::IO,
+          nrows::Integer, ncols::Integer, nchannels::Integer, nsrc::Integer,
+          indices::AbstractVector{<:Integer}, labeltype::Type{T}) where T<:Integer =
+    _readdata!(io, Array{UInt8, 4}(undef, nrows, ncols, nchannels, length(indices)),
+               fill(zero(labeltype), length(indices)), nsrc, indices, 0)
+
+function _readdata(file::AbstractString,
+        nrows::Integer, ncols::Integer, nchannels::Integer, nsrc::Integer,
+        indices::AbstractVector{<:Integer}, labeltype::Type)
     open(file, "r") do io
-        readdata(io)
-    end::Tuple{Array{UInt8,4},Vector{Int}}
+        _readdata(io, nrows, ncols, nchannels, nsrc, indices, labeltype)
+    end
+end
+
+function readdata(source, indices::AbstractVector{<:Integer})
+    images, labels = _readdata(source, NROW, NCOL, NCHAN, CHUNK_SIZE, indices, UInt8)
+    return images, Vector{Int}(labels)
+end
+
+readdata(source, indices::Nothing = nothing) = readdata(source, 1:CHUNK_SIZE)
+
+function readdata(source, index::Integer)
+    images, labels = _readdata(source, NROW, NCOL, NCHAN, CHUNK_SIZE, [index], UInt8)
+    return dropdims(images, dims=4), convert(Int, @inbounds(labels[1]))::Int
 end
 
 end

--- a/src/CIFAR10/utils.jl
+++ b/src/CIFAR10/utils.jl
@@ -29,10 +29,10 @@ function convert2features(array::AbstractArray{<:Number,4})
 end
 
 convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(channelview(array), (3,2,1)))
+    convert2features(permutedims(_channelview(array), (3,2,1)))
 
 convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(channelview(array), (3,2,1,4)))
+    convert2features(permutedims(_channelview(array), (3,2,1,4)))
 
 """
     convert2image(array) -> Array{RGB}
@@ -68,13 +68,13 @@ end
 function convert2image(array::AbstractArray{<:Number,3})
     nrows, ncols, nchan = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,2,1)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,2,1)))
 end
 
 function convert2image(array::AbstractArray{<:Number,4})
     nrows, ncols, nchan, nimages = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,2,1,4)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,2,1,4)))
 end
 
 _norm_array(array::AbstractArray) = array

--- a/src/CIFAR100/CIFAR100.jl
+++ b/src/CIFAR100/CIFAR100.jl
@@ -4,25 +4,14 @@ module CIFAR100
     using BinDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
-    import ..CIFAR10: convert2image, convert2features
+    using ..CIFAR10: convert2image, convert2features
 
     export
-
-        classnames_coarse,
-        classnames_fine,
-
-        traintensor,
-        testtensor,
-
-        trainlabels,
-        testlabels,
-
-        traindata,
-        testdata,
-
-        convert2image,
-        convert2features,
-
+        classnames_coarse, classnames_fine,
+        traintensor, testtensor,
+        trainlabels, testlabels,
+        traindata, testdata,
+        convert2image, convert2features,
         download
 
     const DEPNAME = "CIFAR100"
@@ -49,7 +38,7 @@ module CIFAR100
     """
     download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
 
-    include(joinpath("Reader","Reader.jl"))
+    include(joinpath("Reader", "Reader.jl"))
     include("interface.jl")
 
     function __init__()

--- a/src/CIFAR100/Reader/Reader.jl
+++ b/src/CIFAR100/Reader/Reader.jl
@@ -1,56 +1,28 @@
 module Reader
 
-export
+using ...MLDatasets.CIFAR10.Reader: _readdata
 
-    readdata!,
-    readdata
+export readdata
 
 const NROW = 32
 const NCOL = 32
 const NCHAN = 3
-const NBYTE = NROW * NCOL * NCHAN + 2 # "+ 2" for label
 
-function readnext!(buffer::Array{UInt8}, io::IO)
-    c = Int(read(io, UInt8))
-    f = Int(read(io, UInt8))
-    read!(io, buffer)
-    buffer, c, f
+function readdata(source, nobs::Integer, indices::AbstractVector{<:Integer})
+    images, labels = _readdata(source, NROW, NCOL, NCHAN, nobs, indices, UInt16)
+    return images,
+           Int[(lbl % UInt8) for lbl in labels]::Vector{Int},
+           Int[((lbl >> 8) % UInt8) for lbl in labels]::Vector{Int}
 end
 
-function readdata!(buffer::Array{UInt8}, io::IO, index::Integer)
-    seek(io, (index - 1) * NBYTE)
-    readnext!(buffer, io)
-end
+readdata(source, nobs::Integer, indices::Nothing=nothing) =
+    readdata(source, nobs, 1:nobs)
 
-function readdata(io::IO, nobs::Int, index::Integer)
-    buffer = Array{UInt8}(undef, NROW, NCOL, NCHAN)
-    readdata!(buffer, io, index)
-end
-
-function readdata(io::IO, nobs::Int)
-    X = Array{UInt8}(undef, NROW, NCOL, NCHAN, nobs)
-    C = Array{Int}(undef, nobs)
-    F = Array{Int}(undef, nobs)
-    buffer = Array{UInt8}(undef, NROW, NCOL, NCHAN)
-    @inbounds for index in 1:nobs
-        _, tc, tf = readnext!(buffer, io)
-        copyto!(view(X,:,:,:,index), buffer)
-        C[index] = tc
-        F[index] = tf
-    end
-    X, C, F
-end
-
-function readdata(file::AbstractString, nobs::Int, index::Integer)
-    open(file, "r") do io
-        readdata(io, nobs, index)
-    end::Tuple{Array{UInt8,3},Int,Int}
-end
-
-function readdata(file::AbstractString, nobs::Int)
-    open(file, "r") do io
-        readdata(io, nobs)
-    end::Tuple{Array{UInt8,4},Vector{Int},Vector{Int}}
+function readdata(source, nobs::Integer, index::Integer)
+    images, labels = _readdata(source, NROW, NCOL, NCHAN, nobs, [index], UInt16)
+    return dropdims(images, dims=4),
+           convert(Int, labels[1] % UInt8)::Int,
+           convert(Int, (labels[1] >> 8) % UInt8)::Int
 end
 
 end

--- a/src/FashionMNIST/FashionMNIST.jl
+++ b/src/FashionMNIST/FashionMNIST.jl
@@ -27,25 +27,15 @@ module FashionMNIST
     using DataDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
-    import ..MNIST: convert2image, convert2features
-    import ..MNIST.Reader
+    using ..MNIST: convert2image, convert2features
+    using ..MNIST.Reader
 
     export
-
         classnames,
-
-        traintensor,
-        testtensor,
-
-        trainlabels,
-        testlabels,
-
-        traindata,
-        testdata,
-
-        convert2image,
-        convert2features,
-
+        traintensor, testtensor,
+        trainlabels, testlabels,
+        traindata, testdata,
+        convert2image, convert2features,
         download
 
     const DEPNAME = "FashionMNIST"

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -1,12 +1,40 @@
 module MLDatasets
 
-using FixedPointNumbers
+using Requires
+using FixedPointNumbers, ColorTypes
 
 bytes_to_type(::Type{UInt8}, A::Array{UInt8}) = A
 bytes_to_type(::Type{N0f8}, A::Array{UInt8}) = reinterpret(N0f8, A)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:Integer = convert(Array{T}, A)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:AbstractFloat = A ./ T(255)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:Number  = convert(Array{T}, reinterpret(N0f8, A))
+
+global __images_supported__ = false
+global __matfiles_supported__ = false
+
+function _channelview(image::AbstractArray{<:Color})
+    __images_supported__ ||
+        error("Converting to/from image requires ImageCore package.")
+    channelview(image)
+end
+
+function _colorview(::Type{T}, array::AbstractArray{<:Number}) where T <: Color
+    __images_supported__ ||
+        error("Converting to image requires ImageCore package.")
+    colorview(T, array)
+end
+
+function _matopen(f::Function, path::AbstractString)
+    __matfiles_supported__ ||
+        error("Reading .mat files requires MAT package.")
+    matopen(f, path)
+end
+
+function _matread(path::AbstractString)
+    __matfiles_supported__ ||
+        error("Reading .mat files requires MAT package.")
+    matread(path)
+end
 
 include("download.jl")
 include("CoNLL.jl")
@@ -18,5 +46,17 @@ include("FashionMNIST/FashionMNIST.jl")
 include("SVHN2/SVHN2.jl")
 include("PTBLM/PTBLM.jl")
 include("UD_English/UD_English.jl")
+
+function __init__()
+    # initialize optional dependencies
+    @require ImageCore="a09fc81d-aa75-5fe9-8630-4744c3626534" begin
+        using ImageCore
+        global __images_supported__ = true
+    end
+    @require MAT="23992714-dd62-5051-b70f-ba57cb901cac" begin
+        using MAT
+        global __matfiles_supported__ = true
+    end
+end
 
 end

--- a/src/MNIST/MNIST.jl
+++ b/src/MNIST/MNIST.jl
@@ -25,25 +25,15 @@ the 10 possible digits (0-9).
 """
 module MNIST
     using DataDeps
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring, _colorview
 
     export
-
-        traintensor,
-        testtensor,
-
-        trainlabels,
-        testlabels,
-
-        traindata,
-        testdata,
-
-        convert2image,
-        convert2features,
-
+        traintensor, testtensor,
+        trainlabels, testlabels,
+        traindata, testdata,
+        convert2image, convert2features,
         download
 
     const DEPNAME = "MNIST"
@@ -67,7 +57,7 @@ module MNIST
     """
     download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
 
-    include(joinpath("Reader","Reader.jl"))
+    include(joinpath("Reader", "Reader.jl"))
     include("interface.jl")
     include("utils.jl")
 

--- a/src/MNIST/Reader/Reader.jl
+++ b/src/MNIST/Reader/Reader.jl
@@ -1,18 +1,14 @@
 module Reader
-    using GZip
+    using CodecZlib
     using BinDeps
 
-    export
-        readimages,
-        readlabels
+    export readimages, readlabels
 
     # Constants
-
     const IMAGEOFFSET = 16
     const LABELOFFSET = 8
 
     # Includes
-
     include("readheader.jl")
     include("readimages.jl")
     include("readlabels.jl")

--- a/src/MNIST/Reader/readheader.jl
+++ b/src/MNIST/Reader/readheader.jl
@@ -17,7 +17,8 @@ function readimageheader(io::IO)
     total_items  = bswap(read(io, UInt32))
     nrows = bswap(read(io, UInt32))
     ncols = bswap(read(io, UInt32))
-    UInt32(magic_number), Int(total_items), Int(nrows), Int(ncols)
+    @assert magic_number == 0x803
+    magic_number, Int(total_items), Int(nrows), Int(ncols)
 end
 
 """
@@ -26,9 +27,8 @@ end
 Opens and reads the first four 32 bits values of `file` and
 returns them interpreted as an MNIST-image-file header
 """
-function readimageheader(file::AbstractString)
-    gzopen(readimageheader, file, "r")::Tuple{UInt32,Int,Int,Int}
-end
+readimageheader(file::AbstractString) =
+    open(readimageheader, GzipDecompressorStream, file, "r")
 
 """
     readlabelheader(io::IO)
@@ -42,7 +42,8 @@ storage order.
 function readlabelheader(io::IO)
     magic_number = bswap(read(io, UInt32))
     total_items  = bswap(read(io, UInt32))
-    UInt32(magic_number), Int(total_items)
+    @assert magic_number == 0x801
+    magic_number, Int(total_items)
 end
 
 """
@@ -51,6 +52,5 @@ end
 Opens and reads the first two 32 bits values of `file` and
 returns them interpreted as an MNIST-label-file header
 """
-function readlabelheader(file::AbstractString)
-    gzopen(readlabelheader, file, "r")::Tuple{UInt32,Int}
-end
+readlabelheader(file::AbstractString) =
+    open(readlabelheader, GzipDecompressorStream, file, "r")

--- a/src/MNIST/Reader/readimages.jl
+++ b/src/MNIST/Reader/readimages.jl
@@ -18,12 +18,16 @@ function _readimages(io::IO, nrows::Integer, ncols::Integer,
     else
         buffer = Matrix{UInt8}(undef, nrows, ncols)
         pos = IMAGEOFFSET
+        last_src_ix = 0
         for (dst_ix, src_ix) in zip(dst_indices, src_indices)
-            nextpos = IMAGEOFFSET + imagesize * (src_ix - 1)
-            skip(io, nextpos - pos)
-            read!(io, buffer)
+            if src_ix != last_src_ix
+                nextpos = IMAGEOFFSET + imagesize * (src_ix - 1)
+                skip(io, nextpos - pos)
+                read!(io, buffer)
+                pos = nextpos + imagesize
+                last_src_ix = src_ix
+            end
             copyto!(view(images, :, :, dst_ix), buffer)
-            pos = nextpos + imagesize
         end
     end
     return images

--- a/src/MNIST/Reader/readlabels.jl
+++ b/src/MNIST/Reader/readlabels.jl
@@ -1,66 +1,52 @@
-"""
-    readlabels(io::IO, index::Integer)
-
-Jumps to the position of `io` where the byte for the `index`'th
-label is located and returns the byte at that position as `UInt8`
-"""
-function readlabels(io::IO, index::Integer)
-    seek(io, LABELOFFSET + (index - 1))
-    read(io, UInt8)::UInt8
-end
-
-"""
-    readlabels(io::IO, indices::AbstractVector)
-
-Reads the byte for each label-index in `indices` and stores them
-in a `Vector{UInt8}` of length `length(indices)` in the same order
-as denoted by `indices`.
-"""
-function readlabels(io::IO, indices::AbstractVector)
-    labels = Array{UInt8}(undef, length(indices))
-    dst_index = 1
-    for src_index in indices
-        labels[dst_index] = readlabels(io, src_index)
-        dst_index += 1
+# Reads labels at src_indices positions from io
+# and puts them to dst_indices positions in the resulting vector.
+# src_indices should be sorted in ascending order,
+# otherwise io would fail to go to the already read position.
+function _readlabels(io::IO,
+                     src_indices::AbstractVector{<:Integer},
+                     dst_indices::AbstractVector{<:Integer})
+    @assert length(src_indices) == length(dst_indices)
+    labels = Vector{UInt8}(undef, length(src_indices))
+    pos = LABELOFFSET
+    for (dst_ix, src_ix) in zip(dst_indices, src_indices)
+        nextpos = LABELOFFSET + (src_ix - 1)
+        skip(io, nextpos - pos)
+        labels[dst_ix] = read(io, UInt8)
+        pos = nextpos + 1
     end
-    labels::Vector{UInt8}
+    return labels
 end
 
 """
     readlabels(file::AbstractString, [indices])
+    readlabels(io::IO, [indices])
 
-Reads the label denoted by `indices` from `file`. The given `file`
+Reads the label denoted by `indices` from `file` or `io`. The given file
 is assumed to be in the MNIST label-file format, as it is described
 on the official homepage at http://yann.lecun.com/exdb/mnist/
 
-- if `indices` is an `Integer`, the single label is returned as `UInt8`.
+If specified, `indices` could be either a single 1-based image index or a vector of indices.
+If `indices` is not specified, all images are read.
 
-- if `indices` is a `AbstractVector`, the labels are returned as
-  a `Vector{UInt8}`, length `length(indices)` in the same order as
-  denoted by `indices`.
-
-- if `indices` is ommited all all are returned
-  (as `Vector{UInt8}` as described above)
+Returns a `Vector{UInt8}` with image labels in the same order as `indices`.
 """
-function readlabels(file::AbstractString, index::Integer)
-    gzopen(file, "r") do io
-        _, nlabels = readlabelheader(io)
-        @assert minimum(index) >= 1 && maximum(index) <= nlabels
-        readlabels(io, index)
-    end::UInt8
+function readlabels(io::IO, indices::Union{AbstractVector{<:Integer}, Nothing})
+    _, nlabels = readlabelheader(io)
+    _indices = indices !== nothing ? indices : (1:nlabels)
+    @assert isa(_indices, AbstractVector)
+    all(i -> 1 <= i <= nlabels, _indices) ||
+        throw(ArgumentError("not all elements in parameter \"indices\" are in 1:$nlabels"))
+
+    issorted(_indices) && return _readlabels(io, _indices, 1:length(_indices))
+    # sort indices, because IO might not support seek()
+    perm = sortperm(_indices)
+    return _readlabels(io, _indices[perm], (1:length(_indices))[perm])
 end
 
-function readlabels(file::AbstractString, indices::AbstractVector)
-    gzopen(file, "r") do io
-        _, nlabels = readlabelheader(io)
-        @assert minimum(indices) >= 1 && maximum(indices) <= nlabels
-        readlabels(io, indices)
-    end::Vector{UInt8}
-end
+readlabels(io::IO, index::Integer) = readlabels(io, [index])[1]::UInt8
 
-function readlabels(file::AbstractString)
-    gzopen(file, "r") do io
-        _, nlabels = readlabelheader(io)
-        readlabels(io, 1:nlabels)
-    end::Vector{UInt8}
+function readlabels(file::AbstractString, indices = nothing)
+    open(GzipDecompressorStream, file) do io
+        return readlabels(io, indices)
+    end
 end

--- a/src/MNIST/Reader/readlabels.jl
+++ b/src/MNIST/Reader/readlabels.jl
@@ -8,11 +8,17 @@ function _readlabels(io::IO,
     @assert length(src_indices) == length(dst_indices)
     labels = Vector{UInt8}(undef, length(src_indices))
     pos = LABELOFFSET
+    last_src_ix = 0
+    last_label = UInt8(0)
     for (dst_ix, src_ix) in zip(dst_indices, src_indices)
-        nextpos = LABELOFFSET + (src_ix - 1)
-        skip(io, nextpos - pos)
-        labels[dst_ix] = read(io, UInt8)
-        pos = nextpos + 1
+        if src_ix != last_src_ix
+            nextpos = LABELOFFSET + (src_ix - 1)
+            skip(io, nextpos - pos)
+            last_label = read(io, UInt8)
+            pos = nextpos + 1
+            last_src_ix = src_ix
+        end
+        labels[dst_ix] = last_label
     end
     return labels
 end

--- a/src/MNIST/interface.jl
+++ b/src/MNIST/interface.jl
@@ -50,15 +50,10 @@ julia> MNIST.convert2image(MNIST.traintensor(1)) # convert to column-major color
 
 $(download_docstring("MNIST", DEPNAME))
 """
-function traintensor(::Type{T}, args...; dir = nothing) where T
-    path = datafile(DEPNAME, TRAINIMAGES, dir)
-    images = Reader.readimages(path, args...)
-    bytes_to_type(T, images)
-end
+traintensor(::Type{T}, indices = nothing; dir = nothing) where T =
+    bytes_to_type(T, Reader.readimages(datafile(DEPNAME, TRAINIMAGES, dir), indices))
 
-function traintensor(args...; dir = nothing)
-    traintensor(N0f8, args...; dir = dir)
-end
+traintensor(indices = nothing; dir = nothing) = traintensor(N0f8, indices; dir = dir)
 
 """
     testtensor([T = N0f8], [indices]; [dir]) -> Array{T}
@@ -112,15 +107,10 @@ julia> MNIST.convert2image(MNIST.testtensor(1)) # convert to column-major colora
 
 $(download_docstring("MNIST", DEPNAME))
 """
-function testtensor(::Type{T}, args...; dir = nothing) where T
-    path = datafile(DEPNAME, TESTIMAGES, dir)
-    images = Reader.readimages(path, args...)
-    bytes_to_type(T, images)
-end
+testtensor(::Type{T}, indices = nothing; dir = nothing) where T =
+    bytes_to_type(T, Reader.readimages(datafile(DEPNAME, TESTIMAGES, dir), indices))
 
-function testtensor(args...; dir = nothing)
-    testtensor(N0f8, args...; dir = dir)
-end
+testtensor(indices = nothing; dir = nothing) = testtensor(N0f8, indices; dir = dir)
 
 """
     trainlabels([indices]; [dir])
@@ -151,15 +141,11 @@ julia> MNIST.trainlabels(1) # first label
 
 $(download_docstring("MNIST", DEPNAME))
 """
-function trainlabels(args...; dir = nothing)
-    path = datafile(DEPNAME, TRAINLABELS, dir)
-    Vector{Int}(Reader.readlabels(path, args...))
-end
+trainlabels(indices = nothing; dir = nothing) =
+    Vector{Int}(Reader.readlabels(datafile(DEPNAME, TRAINLABELS, dir), indices))
 
-function trainlabels(index::Integer; dir = nothing)
-    path = datafile(DEPNAME, TRAINLABELS, dir)
-    Int(Reader.readlabels(path, index))
-end
+trainlabels(index::Integer; dir = nothing) =
+    Int(Reader.readlabels(datafile(DEPNAME, TRAINLABELS, dir), index))
 
 """
     testlabels([indices]; [dir])
@@ -190,15 +176,11 @@ julia> MNIST.testlabels(1) # first label
 
 $(download_docstring("MNIST", DEPNAME))
 """
-function testlabels(args...; dir = nothing)
-    path = datafile(DEPNAME, TESTLABELS, dir)
-    Vector{Int}(Reader.readlabels(path, args...))
-end
+testlabels(indices = nothing; dir = nothing) =
+    Vector{Int}(Reader.readlabels(datafile(DEPNAME, TESTLABELS, dir), indices))
 
-function testlabels(index::Integer; dir = nothing)
-    path = datafile(DEPNAME, TESTLABELS, dir)
-    Int(Reader.readlabels(path, index))
-end
+testlabels(index::Integer; dir = nothing) =
+    Int(Reader.readlabels(datafile(DEPNAME, TESTLABELS, dir), index))
 
 """
     traindata([T = N0f8], [indices]; [dir]) -> Tuple
@@ -227,12 +209,11 @@ $(download_docstring("MNIST", DEPNAME))
 Take a look at [`MNIST.traintensor`](@ref) and
 [`MNIST.trainlabels`](@ref) for more information.
 """
-function traindata(::Type{T}, args...; dir = nothing) where T
-    (traintensor(T, args...; dir = dir),
-     trainlabels(args...; dir = dir))
-end
+traindata(::Type{T}, indices = nothing; dir = nothing) where T =
+    (traintensor(T, indices; dir = dir),
+     trainlabels(indices; dir = dir))
 
-traindata(args...; dir = nothing) = traindata(N0f8, args...; dir = dir)
+traindata(indices = nothing; dir = nothing) = traindata(N0f8, indices; dir = dir)
 
 """
     testdata([T = N0f8], [indices]; [dir]) -> Tuple
@@ -261,9 +242,8 @@ $(download_docstring("MNIST", DEPNAME))
 Take a look at [`MNIST.testtensor`](@ref) and
 [`MNIST.testlabels`](@ref) for more information.
 """
-function testdata(::Type{T}, args...; dir = nothing) where T
-    (testtensor(T, args...; dir = dir),
-     testlabels(args...; dir = dir))
-end
+testdata(::Type{T}, indices = nothing; dir = nothing) where T =
+    (testtensor(T, indices; dir = dir),
+     testlabels(indices; dir = dir))
 
-testdata(args...; dir = nothing) = testdata(N0f8, args...; dir = dir)
+testdata(indices = nothing; dir = nothing) = testdata(N0f8, indices; dir = dir)

--- a/src/MNIST/utils.jl
+++ b/src/MNIST/utils.jl
@@ -55,9 +55,9 @@ function convert2image(array::AbstractMatrix{T}) where {T<:Number}
     if size(array) == (28, 28)
         # simple check to see if values are normalized to [0,1]
         if any(x->x > 50, array)
-            colorview(Gray, T(1) .- transpose(array) ./ T(255))
+            _colorview(Gray, T(1) .- transpose(array) ./ T(255))
         else
-            colorview(Gray, T(1) .- transpose(array))
+            _colorview(Gray, T(1) .- transpose(array))
         end
     else # feature matrix
         @assert size(array, 1) == 784
@@ -71,8 +71,8 @@ function convert2image(array::AbstractArray{T,3}) where {T<:Number}
     @assert h == 28 && w == 28
     # simple check to see if values are normalized to [0,1]
     if any(x->x > 50, array)
-        colorview(Gray, permutedims(T(1) .- array ./ T(255), [2,1,3]))
+        _colorview(Gray, permutedims(T(1) .- array ./ T(255), [2,1,3]))
     else
-        colorview(Gray, permutedims(T(1) .- array, [2,1,3]))
+        _colorview(Gray, permutedims(T(1) .- array, [2,1,3]))
     end
 end

--- a/src/PTBLM/PTBLM.jl
+++ b/src/PTBLM/PTBLM.jl
@@ -5,10 +5,7 @@ module PTBLM
     using ..MLDatasets: datafile, download_dep
 
     export
-
-        traindata,
-        testdata,
-
+        traindata, testdata,
         download
 
     const DEPNAME = "PTBLM"

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -30,29 +30,16 @@ additional to use as extra training data.
 """
 module SVHN2
     using DataDeps
-    using MAT
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring,
+                        _colorview, _channelview, _matopen, _matread
 
     export
-
-        traintensor,
-        testtensor,
-        extratensor,
-
-        trainlabels,
-        testlabels,
-        extralabels,
-
-        traindata,
-        testdata,
-        extradata,
-
-        convert2image,
-        convert2features,
-
+        traintensor, testtensor, extratensor,
+        trainlabels, testlabels, extralabels,
+        traindata, testdata, extradata,
+        convert2image, convert2features,
         download
 
     const DEPNAME = "SVHN2"
@@ -70,7 +57,7 @@ module SVHN2
 
     This function will display an interactive dialog unless
     either the keyword parameter `i_accept_the_terms_of_use` or
-    the environment variable `DATADEPS_ALWAY_ACCEPT` is set to
+    the environment variable `DATADEPS_ALWAYS_ACCEPT` is set to
     `true`. Note that using the data responsibly and respecting
     copyright/terms-of-use remains your responsibility.
     """

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -29,10 +29,10 @@ function convert2features(array::AbstractArray{<:Number,4})
 end
 
 convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(channelview(array), (2,3,1)))
+    convert2features(permutedims(_channelview(array), (2,3,1)))
 
 convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(channelview(array), (2,3,1,4)))
+    convert2features(permutedims(_channelview(array), (2,3,1,4)))
 
 """
     convert2image(array) -> Array{RGB}
@@ -68,13 +68,13 @@ end
 function convert2image(array::AbstractArray{<:Number,3})
     nrows, ncols, nchan = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,1,2)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,1,2)))
 end
 
 function convert2image(array::AbstractArray{<:Number,4})
     nrows, ncols, nchan, nimages = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,1,2,4)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,1,2,4)))
 end
 
 _norm_array(array::AbstractArray) = array

--- a/src/UD_English/UD_English.jl
+++ b/src/UD_English/UD_English.jl
@@ -6,10 +6,7 @@ module UD_English
     using ..MLDatasets: datafile, download_dep
 
     export
-
-        traindata,
-        testdata,
-
+        traindata, testdata,
         download
 
     const DEPNAME = "UD_English"

--- a/src/download.jl
+++ b/src/download.jl
@@ -1,4 +1,3 @@
-import BinDeps
 using DataDeps
 
 function with_accept(f, manual_overwrite)
@@ -12,41 +11,37 @@ end
 
 function datadir(depname, dir = nothing; i_accept_the_terms_of_use = nothing)
     with_accept(i_accept_the_terms_of_use) do
-        if dir == nothing
+        if dir === nothing
             # use DataDeps defaults
-            @datadep_str depname
+            return @datadep_str depname
         else
             # use user-provided dir
-            if isdir(dir)
-                dir
-            else
-                DataDeps.env_bool("DATADEPS_DISABLE_DOWNLOAD") && error("DATADEPS_DISABLE_DOWNLOAD enviroment variable set. Can not trigger download.")
-                DataDeps.download(DataDeps.registry[depname], dir)
-                dir
-            end
+            isdir(dir) && return dir
+            DataDeps.env_bool("DATADEPS_DISABLE_DOWNLOAD") && error("DATADEPS_DISABLE_DOWNLOAD enviroment variable set. Can not trigger download.")
+            DataDeps.download(DataDeps.registry[depname], dir)
+            return dir
         end
-    end::String
+    end
 end
 
 function datafile(depname, filename, dir = nothing; recurse = true, kw...)
     path = joinpath(datadir(depname, dir; kw...), filename)
-    if !isfile(path)
-        warn("The file \"$path\" does not exist, even though the dataset-specific folder does. This is an unusual situation that may have been caused by a manual creation of an empty folder, or manual deletion of the given file \"$filename\".")
-        if dir == nothing
-            info("Retriggering DataDeps.jl for \"$depname\"")
-            download_dep(depname; kw...)
-        else
-            info("Retriggering DataDeps.jl for \"$depname\" to \"$dir\".")
-            download_dep(depname, dir; kw...)
-        end
-        if recurse
-            datafile(depname, filename, dir; recurse = false, kw...)
-        else
-            error("The file \"$path\" still does not exist. One possible explaination could be a spelling error in the name of the requested file.")
-        end
+    isfile(path) && return path
+
+    @warn "The file \"$path\" does not exist, even though the dataset-specific folder does. This is an unusual situation that may have been caused by a manual creation of an empty folder, or manual deletion of the given file \"$filename\"."
+    if dir === nothing
+        @info "Retriggering DataDeps.jl for \"$depname\""
+        download_dep(depname; kw...)
     else
-        path
-    end::String
+        @info "Retriggering DataDeps.jl for \"$depname\" to \"$dir\"."
+        download_dep(depname, dir; kw...)
+    end
+
+    if recurse
+        return datafile(depname, filename, dir; recurse = false, kw...)
+    else
+        error("The file \"$path\" still does not exist. One possible explaination could be a spelling error in the name of the requested file.")
+    end
 end
 
 function download_dep(depname, dir = DataDeps.determine_save_path(depname); kw...)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,3 @@
+ImageCore 0.1.2
+ColorTypes 0.4
+MAT 0.4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,31 +1,43 @@
 using Test
 using MLDatasets
 
-tests = [
-    "tst_cifar10.jl",
-    "tst_cifar100.jl",
-    "tst_mnist.jl",
-    "tst_fashion_mnist.jl",
-    "tst_svhn2.jl",
-]
+module MLDatasetsTestUtils
+export isCI
 
-for t in tests
-    @testset "$t" begin
-        include(t)
-    end
+# detect whether the tests are running in CI environment
+isCI() = parse(Bool, get(ENV, "CI", "false"))
+end # module
+
+@testset "CIFAR10" begin
+    include("tst_cifar10.jl")
+end
+@testset "CIFAR100" begin
+    include("tst_cifar100.jl")
+end
+@testset "MNIST" begin
+    include("tst_mnist.jl")
+end
+@testset "FashionMNIST" begin
+    include("tst_fashion_mnist.jl")
+end
+@testset "SVHN2" begin
+    include("tst_svhn2.jl")
 end
 
+using .MLDatasetsTestUtils
+
 # temporary to not stress CI
-if !parse(Bool, get(ENV, "CI", "false"))
-    @testset "other tests" begin
-        # PTBLM
+if !isCI()
+    @testset "PTBLM" begin
         x, y = PTBLM.traindata()
         x, y = PTBLM.testdata()
+    end
 
-        # UD_English
+    @testset "UD_English" begin
         x = UD_English.traindata()
         x = UD_English.devdata()
         x = UD_English.testdata()
     end
 end
+
 nothing

--- a/test/tst_cifar10.jl
+++ b/test/tst_cifar10.jl
@@ -5,12 +5,12 @@ using ImageCore
 using FixedPointNumbers
 using MLDatasets
 using DataDeps
+using ..MLDatasetsTestUtils
 
 @testset "Constants" begin
     @test CIFAR10.Reader.NROW === 32
     @test CIFAR10.Reader.NCOL === 32
     @test CIFAR10.Reader.NCHAN === 3
-    @test CIFAR10.Reader.NBYTE === 3073
     @test CIFAR10.Reader.CHUNK_SIZE === 10000
 
     @test CIFAR10.NCHUNKS === 5
@@ -57,10 +57,10 @@ end
 
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
-if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+if isCI()
+    @info "CI detected: skipping dataset download"
 else
-    data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+    data_dir = withenv("DATADEPS_ALWAYS_ACCEPT"=>"true") do
         datadep"CIFAR10"
     end
 
@@ -122,7 +122,7 @@ else
         # as int or as vector). That means no matter how you
         # specify an index, you will always get the same result
         # for a specific index.
-        for (image_fun, T, nimages) in (
+        @testset "$image_fun with T=$T" for (image_fun, T, nimages) in (
                 (CIFAR10.traintensor, Float32, 50_000),
                 (CIFAR10.traintensor, Float64, 50_000),
                 (CIFAR10.traintensor, N0f8,    50_000),
@@ -134,47 +134,43 @@ else
                 (CIFAR10.testtensor,  Int,     10_000),
                 (CIFAR10.testtensor,  UInt8,   10_000)
             )
-            @testset "$image_fun with T=$T" begin
-                # whole image set
-                A = @inferred image_fun(T)
-                @test typeof(A) <: Union{Array{T,4},Base.ReinterpretArray{T,4}}
-                @test size(A) == (32,32,3,nimages)
+            # whole image set
+            A = @inferred image_fun(T)
+            @test A isa AbstractArray{T,4}
+            @test size(A) == (32,32,3,nimages)
 
-                @test_throws AssertionError image_fun(T,-1)
-                @test_throws AssertionError image_fun(T,0)
-                @test_throws AssertionError image_fun(T,nimages+1)
+            @test_throws ArgumentError image_fun(T,-1)
+            @test_throws ArgumentError image_fun(T,0)
+            @test_throws ArgumentError image_fun(T,nimages+1)
 
-                @testset "load single images" begin
-                    # Sample a few random images to compare
-                    for i = rand(1:nimages, 10)
-                        A_i = @inferred image_fun(T,i)
-                        @test typeof(A_i) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                        @test size(A_i) == (32,32,3)
-                        @test A_i == A[:,:,:,i]
-                    end
+            @testset "load single images" begin
+                # Sample a few random images to compare
+                for i = rand(1:nimages, 10)
+                    A_i = @inferred image_fun(T,i)
+                    @test A_i isa AbstractArray{T,3}
+                    @test size(A_i) == (32,32,3)
+                    @test A_i == A[:,:,:,i]
+                end
+            end
+
+            @testset "load multiple images" begin
+                A_5_10 = @inferred image_fun(T,5:10)
+                @test A_5_10 isa AbstractArray{T,4}
+                @test size(A_5_10) == (32,32,3,6)
+                for i = 1:6
+                    @test A_5_10[:,:,:,i] == A[:,:,:,i+4]
                 end
 
-                @testset "load multiple images" begin
-                    A_5_10 = @inferred image_fun(T,5:10)
-                    @test typeof(A_5_10) <: Union{Array{T,4},Base.ReinterpretArray{T,4}}
-                    @test size(A_5_10) == (32,32,3,6)
-                    for i = 1:6
-                        @test A_5_10[:,:,:,i] == A[:,:,:,i+4]
-                    end
-
-                    # also test edge cases `1`, `nimages`
-                    indices = [10,3,9,1,nimages]
-                    A_vec   = image_fun(T,indices)
-                    A_vec_f = image_fun(T,Vector{Int32}(indices))
-                    @test typeof(A_vec) <: Union{Array{T,4},Base.ReinterpretArray{T,4}}
-                    @test typeof(A_vec_f) <: Union{Array{T,4},Base.ReinterpretArray{T,4}}
-                    @test size(A_vec)   == (32,32,3,5)
-                    @test size(A_vec_f) == (32,32,3,5)
-                    for i in 1:5
-                        @test A_vec[:,:,:,i] == A[:,:,:,indices[i]]
-                        @test A_vec[:,:,:,i] == A_vec_f[:,:,:,i]
-                    end
-                end
+                # also test edge cases `1`, `nimages`
+                indices = [10,3,9,1,nimages]
+                A_vec   = image_fun(T,indices)
+                A_vec_f = image_fun(T,Vector{Int32}(indices))
+                @test A_vec   isa AbstractArray{T,4}
+                @test A_vec_f isa AbstractArray{T,4}
+                @test size(A_vec)   == (32,32,3,5)
+                @test size(A_vec_f) == (32,32,3,5)
+                @test A_vec == A[:,:,:,indices]
+                @test A_vec == A_vec_f
             end
         end
     end
@@ -204,78 +200,74 @@ else
         # for a specific index.
         # -- However, technically these tests do not check if
         #    these are the actual CIFAR10 labels of that index!
-        for (label_fun, nlabels) in
+        @testset "$label_fun" for (label_fun, nlabels) in
                     ((CIFAR10.trainlabels, 50_000),
                      (CIFAR10.testlabels,  10_000))
-            @testset "$label_fun" begin
-                # whole label set
-                A = @inferred label_fun()
-                @test typeof(A) <: Vector{Int64}
-                @test size(A) == (nlabels,)
+            # whole label set
+            A = @inferred label_fun()
+            @test A isa Vector{Int64}
+            @test size(A) == (nlabels,)
 
-                @testset "load single label" begin
-                    # Sample a few random labels to compare
-                    for i = rand(1:nlabels, 10)
-                        A_i = @inferred label_fun(i)
-                        @test typeof(A_i) <: Int64
-                        @test A_i == A[i]
-                    end
+            @testset "load single label" begin
+                # Sample a few random labels to compare
+                for i = rand(1:nlabels, 10)
+                    A_i = @inferred label_fun(i)
+                    @test A_i isa Int64
+                    @test A_i == A[i]
+                end
+            end
+
+            @testset "load multiple labels" begin
+                A_5_10 = @inferred label_fun(5:10)
+                @test A_5_10 isa Vector{Int64}
+                @test size(A_5_10) == (6,)
+                for i = 1:6
+                    @test A_5_10[i] == A[i+4]
                 end
 
-                @testset "load multiple labels" begin
-                    A_5_10 = @inferred label_fun(5:10)
-                    @test typeof(A_5_10) <: Vector{Int64}
-                    @test size(A_5_10) == (6,)
-                    for i = 1:6
-                        @test A_5_10[i] == A[i+4]
-                    end
-
-                    # also test edge cases `1`, `nlabels`
-                    indices = [10,3,9,1,nlabels]
-                    A_vec   = @inferred label_fun(indices)
-                    A_vec_f = @inferred label_fun(Vector{Int32}(indices))
-                    @test typeof(A_vec)   <: Vector{Int64}
-                    @test typeof(A_vec_f) <: Vector{Int64}
-                    @test size(A_vec)   == (5,)
-                    @test size(A_vec_f) == (5,)
-                    for i in 1:5
-                        @test A_vec[i] == A[indices[i]]
-                        @test A_vec[i] == A_vec_f[i]
-                    end
-                end
+                # also test edge cases `1`, `nlabels`
+                indices = [10,3,9,1,nlabels]
+                A_vec   = @inferred label_fun(indices)
+                A_vec_f = @inferred label_fun(Vector{Int32}(indices))
+                @test A_vec   isa Vector{Int64}
+                @test A_vec_f isa Vector{Int64}
+                @test size(A_vec)   == (5,)
+                @test size(A_vec_f) == (5,)
+                @test A_vec == A[indices]
+                @test A_vec == A_vec_f
             end
         end
     end
 
     # Check against the already tested tensor and labels functions
     @testset "Data" begin
-        for (data_fun, feature_fun, label_fun, nobs) in
+        @testset "check $data_fun against $feature_fun and $label_fun" for
+            (data_fun, feature_fun, label_fun, nobs) in
                 ((CIFAR10.traindata, CIFAR10.traintensor, CIFAR10.trainlabels, 50_000),
                  (CIFAR10.testdata,  CIFAR10.testtensor,  CIFAR10.testlabels,  10_000))
-            @testset "check $data_fun against $feature_fun and $label_fun" begin
-                data, labels = @inferred data_fun()
-                @test data == @inferred feature_fun()
-                @test labels == @inferred label_fun()
 
-                for i = rand(1:nobs, 10)
-                    d_i, l_i = @inferred data_fun(i)
-                    @test d_i == @inferred feature_fun(i)
-                    @test l_i == @inferred label_fun(i)
-                end
+            data, labels = @inferred data_fun()
+            @test data == @inferred feature_fun()
+            @test labels == @inferred label_fun()
 
-                data, labels = @inferred data_fun(5:10)
-                @test data == @inferred feature_fun(5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                data, labels = @inferred data_fun(Int, 5:10)
-                @test data == @inferred feature_fun(Int, 5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                indices = [10,3,9,1,nobs]
-                data, labels = @inferred data_fun(indices)
-                @test data == @inferred feature_fun(indices)
-                @test labels == @inferred label_fun(indices)
+            for i = rand(1:nobs, 10)
+                d_i, l_i = @inferred data_fun(i)
+                @test d_i == @inferred feature_fun(i)
+                @test l_i == @inferred label_fun(i)
             end
+
+            data, labels = @inferred data_fun(5:10)
+            @test data == @inferred feature_fun(5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            data, labels = @inferred data_fun(Int, 5:10)
+            @test data == @inferred feature_fun(Int, 5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            indices = [10,3,9,1,nobs]
+            data, labels = @inferred data_fun(indices)
+            @test data == @inferred feature_fun(indices)
+            @test labels == @inferred label_fun(indices)
         end
     end
 end

--- a/test/tst_cifar10.jl
+++ b/test/tst_cifar10.jl
@@ -162,13 +162,13 @@ else
                 end
 
                 # also test edge cases `1`, `nimages`
-                indices = [10,3,9,1,nimages]
+                indices = [10,1,3,3,9,1,nimages]
                 A_vec   = image_fun(T,indices)
                 A_vec_f = image_fun(T,Vector{Int32}(indices))
                 @test A_vec   isa AbstractArray{T,4}
                 @test A_vec_f isa AbstractArray{T,4}
-                @test size(A_vec)   == (32,32,3,5)
-                @test size(A_vec_f) == (32,32,3,5)
+                @test size(A_vec)   == (32,32,3,7)
+                @test size(A_vec_f) == (32,32,3,7)
                 @test A_vec == A[:,:,:,indices]
                 @test A_vec == A_vec_f
             end
@@ -226,13 +226,13 @@ else
                 end
 
                 # also test edge cases `1`, `nlabels`
-                indices = [10,3,9,1,nlabels]
+                indices = [10,1,3,3,9,1,nlabels]
                 A_vec   = @inferred label_fun(indices)
                 A_vec_f = @inferred label_fun(Vector{Int32}(indices))
                 @test A_vec   isa Vector{Int64}
                 @test A_vec_f isa Vector{Int64}
-                @test size(A_vec)   == (5,)
-                @test size(A_vec_f) == (5,)
+                @test size(A_vec)   == (7,)
+                @test size(A_vec_f) == (7,)
                 @test A_vec == A[indices]
                 @test A_vec == A_vec_f
             end
@@ -264,7 +264,7 @@ else
             @test data == @inferred feature_fun(Int, 5:10)
             @test labels == @inferred label_fun(5:10)
 
-            indices = [10,3,9,1,nobs]
+            indices = [10,1,3,3,9,1,nobs]
             data, labels = @inferred data_fun(indices)
             @test data == @inferred feature_fun(indices)
             @test labels == @inferred label_fun(indices)

--- a/test/tst_cifar100.jl
+++ b/test/tst_cifar100.jl
@@ -125,13 +125,13 @@ else
                     @test A_5_10 == A[:,:,:,5:10]
 
                     # also test edge cases `1`, `nimages`
-                    indices = [10,3,9,1,nimages]
+                    indices = [10,1,3,3,9,1,nimages]
                     A_vec   = image_fun(T,indices)
                     A_vec_f = image_fun(T,Vector{Int32}(indices))
                     @test A_vec   isa AbstractArray{T,4}
                     @test A_vec_f isa AbstractArray{T,4}
-                    @test size(A_vec)   == (32,32,3,5)
-                    @test size(A_vec_f) == (32,32,3,5)
+                    @test size(A_vec)   == (32,32,3,7)
+                    @test size(A_vec_f) == (32,32,3,7)
                     @test A_vec == A[:,:,:,indices]
                     @test A_vec == A_vec_f
                 end
@@ -195,17 +195,17 @@ else
                 @test B_5_10 == B[5:10]
 
                 # also test edge cases `1`, `nlabels`
-                indices = [10,3,9,1,nlabels]
+                indices = [10,1,3,3,9,1,nlabels]
                 A_vec, B_vec     = @inferred label_fun(indices)
                 A_vec_f, B_vec_f = @inferred label_fun(Vector{Int32}(indices))
                 @test A_vec   isa Vector{Int64}
                 @test A_vec_f isa Vector{Int64}
-                @test size(A_vec)   == (5,)
-                @test size(A_vec_f) == (5,)
+                @test size(A_vec)   == (7,)
+                @test size(A_vec_f) == (7,)
                 @test B_vec   isa Vector{Int64}
                 @test B_vec_f isa Vector{Int64}
-                @test size(B_vec)   == (5,)
-                @test size(B_vec_f) == (5,)
+                @test size(B_vec)   == (7,)
+                @test size(B_vec_f) == (7,)
                 @test A_vec == A[indices]
                 @test A_vec == A_vec_f
                 @test B_vec == B[indices]
@@ -239,7 +239,7 @@ else
             @test data == @inferred feature_fun(Int, 5:10)
             @test (l1, l2) == @inferred label_fun(5:10)
 
-            indices = [10,3,9,1,nobs]
+            indices = [10,1,3,3,9,1,nobs]
             data, l1, l2 = @inferred data_fun(indices)
             @test data == @inferred feature_fun(indices)
             @test (l1, l2) == @inferred label_fun(indices)

--- a/test/tst_fashion_mnist.jl
+++ b/test/tst_fashion_mnist.jl
@@ -105,13 +105,13 @@ else
                 @test A_5_10 == A[:,:,5:10]
 
                 # also test edge cases `1`, `nimages`
-                indices = [10,3,9,1,nimages]
+                indices = [10,1,3,3,9,1,nimages]
                 A_vec   = image_fun(T,indices)
                 A_vec_f = image_fun(T,Vector{Int32}(indices))
                 @test A_vec   isa AbstractArray{T,3}
                 @test A_vec_f isa AbstractArray{T,3}
-                @test size(A_vec)   == (28,28,5)
-                @test size(A_vec_f) == (28,28,5)
+                @test size(A_vec)   == (28,28,7)
+                @test size(A_vec_f) == (28,28,7)
                 @test A_vec == A[:,:,indices]
                 @test A_vec == A_vec_f
             end
@@ -164,13 +164,13 @@ else
                 @test A_5_10 == A[5:10]
 
                 # also test edge cases `1`, `nlabels`
-                indices = [10,3,9,1,nlabels]
+                indices = [10,1,3,3,9,1,nlabels]
                 A_vec   = @inferred label_fun(indices)
                 A_vec_f = @inferred label_fun(Vector{Int32}(indices))
                 @test A_vec   isa Vector{Int64}
                 @test A_vec_f isa Vector{Int64}
-                @test size(A_vec)   == (5,)
-                @test size(A_vec_f) == (5,)
+                @test size(A_vec)   == (7,)
+                @test size(A_vec_f) == (7,)
                 @test A_vec == A[indices]
                 @test A_vec == A_vec_f
             end
@@ -202,7 +202,7 @@ else
             @test data == @inferred feature_fun(Int, 5:10)
             @test labels == @inferred label_fun(5:10)
 
-            indices = [10,3,9,1,nobs]
+            indices = [10,1,3,3,9,1,nobs]
             data, labels = @inferred data_fun(indices)
             @test data == @inferred feature_fun(indices)
             @test labels == @inferred label_fun(indices)

--- a/test/tst_fashion_mnist.jl
+++ b/test/tst_fashion_mnist.jl
@@ -1,9 +1,11 @@
 module FashionMNIST_Tests
 using Test
 using ColorTypes
+using ImageCore
 using FixedPointNumbers
 using MLDatasets
 using DataDeps
+using ..MLDatasetsTestUtils
 
 @testset "Constants" begin
     @test FashionMNIST.TRAINIMAGES == "train-images-idx3-ubyte.gz"
@@ -27,10 +29,10 @@ end
 
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
-if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+if isCI()
+    @info "CI detected: skipping dataset download"
 else
-    data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+    data_dir = withenv("DATADEPS_ALWAYS_ACCEPT"=>"true") do
         datadep"FashionMNIST"
     end
 
@@ -65,7 +67,7 @@ else
         # as int or as vector). That means no matter how you
         # specify an index, you will always get the same result
         # for a specific index.
-        for (image_fun, T, nimages) in (
+        @testset "$image_fun with T=$T" for (image_fun, T, nimages) in (
                 (FashionMNIST.traintensor, Float32, 60_000),
                 (FashionMNIST.traintensor, Float64, 60_000),
                 (FashionMNIST.traintensor, N0f8,    60_000),
@@ -77,47 +79,41 @@ else
                 (FashionMNIST.testtensor,  Int,     10_000),
                 (FashionMNIST.testtensor,  UInt8,   10_000)
             )
-            @testset "$image_fun with T=$T" begin
-                # whole image set
-                A = @inferred image_fun(T)
-                @test typeof(A) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                @test size(A) == (28,28,nimages)
+            # whole image set
+            A = @inferred image_fun(T)
+            @test A isa AbstractArray{T,3}
+            @test size(A) == (28,28,nimages)
 
-                @test_throws AssertionError image_fun(T,-1)
-                @test_throws AssertionError image_fun(T,0)
-                @test_throws AssertionError image_fun(T,nimages+1)
+            @test_throws ArgumentError image_fun(T,-1)
+            @test_throws ArgumentError image_fun(T,0)
+            @test_throws ArgumentError image_fun(T,nimages+1)
 
-                @testset "load single images" begin
-                    # Sample a few random images to compare
-                    for i = rand(1:nimages, 10)
-                        A_i = @inferred image_fun(T,i)
-                        @test typeof(A_i) <: Union{Array{T,2},Base.ReinterpretArray{T,2}}
-                        @test size(A_i) == (28,28)
-                        @test A_i == A[:,:,i]
-                    end
+            @testset "load single images" begin
+                # Sample a few random images to compare
+                for i = rand(1:nimages, 10)
+                    A_i = @inferred image_fun(T,i)
+                    @test A_i isa AbstractArray{T,2}
+                    @test size(A_i) == (28,28)
+                    @test A_i == A[:,:,i]
                 end
+            end
 
-                @testset "load multiple images" begin
-                    A_5_10 = @inferred image_fun(T,5:10)
-                    @test typeof(A_5_10) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test size(A_5_10) == (28,28,6)
-                    for i = 1:6
-                        @test A_5_10[:,:,i] == A[:,:,i+4]
-                    end
+            @testset "load multiple images" begin
+                A_5_10 = @inferred image_fun(T,5:10)
+                @test A_5_10 isa AbstractArray{T,3}
+                @test size(A_5_10) == (28,28,6)
+                @test A_5_10 == A[:,:,5:10]
 
-                    # also test edge cases `1`, `nimages`
-                    indices = [10,3,9,1,nimages]
-                    A_vec   = image_fun(T,indices)
-                    A_vec_f = image_fun(T,Vector{Int32}(indices))
-                    @test typeof(A_vec) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test typeof(A_vec_f) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test size(A_vec)   == (28,28,5)
-                    @test size(A_vec_f) == (28,28,5)
-                    for i in 1:5
-                        @test A_vec[:,:,i] == A[:,:,indices[i]]
-                        @test A_vec[:,:,i] == A_vec_f[:,:,i]
-                    end
-                end
+                # also test edge cases `1`, `nimages`
+                indices = [10,3,9,1,nimages]
+                A_vec   = image_fun(T,indices)
+                A_vec_f = image_fun(T,Vector{Int32}(indices))
+                @test A_vec   isa AbstractArray{T,3}
+                @test A_vec_f isa AbstractArray{T,3}
+                @test size(A_vec)   == (28,28,5)
+                @test size(A_vec_f) == (28,28,5)
+                @test A_vec == A[:,:,indices]
+                @test A_vec == A_vec_f
             end
         end
     end
@@ -143,78 +139,73 @@ else
         # for a specific index.
         # -- However, technically these tests do not check if
         #    these are the actual FashionMNIST labels of that index!
-        for (label_fun, nlabels) in
-                    ((FashionMNIST.trainlabels, 60_000),
-                    (FashionMNIST.testlabels,  10_000))
-            @testset "$label_fun" begin
-                # whole label set
-                A = @inferred label_fun()
-                @test typeof(A) <: Vector{Int64}
-                @test size(A) == (nlabels,)
+        @testset "$label_fun" for (label_fun, nlabels) in
+                ((FashionMNIST.trainlabels, 60_000),
+                (FashionMNIST.testlabels,  10_000))
 
-                @testset "load single label" begin
-                    # Sample a few random labels to compare
-                    for i = rand(1:nlabels, 10)
-                        A_i = @inferred label_fun(i)
-                        @test typeof(A_i) <: Int64
-                        @test A_i == A[i]
-                    end
+            # whole label set
+            A = @inferred label_fun()
+            @test A isa Vector{Int64}
+            @test size(A) == (nlabels,)
+
+            @testset "load single label" begin
+                # Sample a few random labels to compare
+                for i = rand(1:nlabels, 10)
+                    A_i = @inferred label_fun(i)
+                    @test A_i isa Int64
+                    @test A_i == A[i]
                 end
+            end
 
-                @testset "load multiple labels" begin
-                    A_5_10 = @inferred label_fun(5:10)
-                    @test typeof(A_5_10) <: Vector{Int64}
-                    @test size(A_5_10) == (6,)
-                    for i = 1:6
-                        @test A_5_10[i] == A[i+4]
-                    end
+            @testset "load multiple labels" begin
+                A_5_10 = @inferred label_fun(5:10)
+                @test A_5_10 isa Vector{Int64}
+                @test size(A_5_10) == (6,)
+                @test A_5_10 == A[5:10]
 
-                    # also test edge cases `1`, `nlabels`
-                    indices = [10,3,9,1,nlabels]
-                    A_vec   = @inferred label_fun(indices)
-                    A_vec_f = @inferred label_fun(Vector{Int32}(indices))
-                    @test typeof(A_vec)   <: Vector{Int64}
-                    @test typeof(A_vec_f) <: Vector{Int64}
-                    @test size(A_vec)   == (5,)
-                    @test size(A_vec_f) == (5,)
-                    for i in 1:5
-                        @test A_vec[i] == A[indices[i]]
-                        @test A_vec[i] == A_vec_f[i]
-                    end
-                end
+                # also test edge cases `1`, `nlabels`
+                indices = [10,3,9,1,nlabels]
+                A_vec   = @inferred label_fun(indices)
+                A_vec_f = @inferred label_fun(Vector{Int32}(indices))
+                @test A_vec   isa Vector{Int64}
+                @test A_vec_f isa Vector{Int64}
+                @test size(A_vec)   == (5,)
+                @test size(A_vec_f) == (5,)
+                @test A_vec == A[indices]
+                @test A_vec == A_vec_f
             end
         end
     end
 
     # Check against the already tested tensor and labels functions
     @testset "Data" begin
-        for (data_fun, feature_fun, label_fun, nobs) in
+        @testset "check $data_fun against $feature_fun and $label_fun" for
+            (data_fun, feature_fun, label_fun, nobs) in
                 ((FashionMNIST.traindata, FashionMNIST.traintensor, FashionMNIST.trainlabels, 60_000),
                 (FashionMNIST.testdata,  FashionMNIST.testtensor,  FashionMNIST.testlabels,  10_000))
-            @testset "check $data_fun against $feature_fun and $label_fun" begin
-                data, labels = @inferred data_fun()
-                @test data == @inferred feature_fun()
-                @test labels == @inferred label_fun()
 
-                for i = rand(1:nobs, 10)
-                    d_i, l_i = @inferred data_fun(i)
-                    @test d_i == @inferred feature_fun(i)
-                    @test l_i == @inferred label_fun(i)
-                end
+            data, labels = @inferred data_fun()
+            @test data == @inferred feature_fun()
+            @test labels == @inferred label_fun()
 
-                data, labels = @inferred data_fun(5:10)
-                @test data == @inferred feature_fun(5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                data, labels = @inferred data_fun(Int, 5:10)
-                @test data == @inferred feature_fun(Int, 5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                indices = [10,3,9,1,nobs]
-                data, labels = @inferred data_fun(indices)
-                @test data == @inferred feature_fun(indices)
-                @test labels == @inferred label_fun(indices)
+            for i = rand(1:nobs, 10)
+                d_i, l_i = @inferred data_fun(i)
+                @test d_i == @inferred feature_fun(i)
+                @test l_i == @inferred label_fun(i)
             end
+
+            data, labels = @inferred data_fun(5:10)
+            @test data == @inferred feature_fun(5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            data, labels = @inferred data_fun(Int, 5:10)
+            @test data == @inferred feature_fun(Int, 5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            indices = [10,3,9,1,nobs]
+            data, labels = @inferred data_fun(indices)
+            @test data == @inferred feature_fun(indices)
+            @test labels == @inferred label_fun(indices)
         end
     end
 end

--- a/test/tst_mnist.jl
+++ b/test/tst_mnist.jl
@@ -1,9 +1,11 @@
 module MNIST_Tests
 using Test
 using ColorTypes
+using ImageCore
 using FixedPointNumbers
 using MLDatasets
 using DataDeps
+using ..MLDatasetsTestUtils
 
 @testset "Constants" begin
     @test MNIST.Reader.IMAGEOFFSET == 16
@@ -50,10 +52,10 @@ end
 
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
-if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+if isCI()
+    @info "CI detected: skipping dataset download"
 else
-    data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+    data_dir = withenv("DATADEPS_ALWAYS_ACCEPT"=>"true") do
         datadep"MNIST"
     end
 
@@ -106,7 +108,7 @@ else
         # as int or as vector). That means no matter how you
         # specify an index, you will always get the same result
         # for a specific index.
-        for (image_fun, T, nimages) in (
+        @testset "$image_fun with T=$T" for (image_fun, T, nimages) in (
                 (MNIST.traintensor, Float32, 60_000),
                 (MNIST.traintensor, Float64, 60_000),
                 (MNIST.traintensor, N0f8,    60_000),
@@ -118,47 +120,41 @@ else
                 (MNIST.testtensor,  Int,     10_000),
                 (MNIST.testtensor,  UInt8,   10_000)
             )
-            @testset "$image_fun with T=$T" begin
-                # whole image set
-                A = @inferred image_fun(T)
-                @test typeof(A) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                @test size(A) == (28,28,nimages)
+            # whole image set
+            A = @inferred image_fun(T)
+            @test A isa AbstractArray{T,3}
+            @test size(A) == (28,28,nimages)
 
-                @test_throws AssertionError image_fun(T,-1)
-                @test_throws AssertionError image_fun(T,0)
-                @test_throws AssertionError image_fun(T,nimages+1)
+            @test_throws ArgumentError image_fun(T,-1)
+            @test_throws ArgumentError image_fun(T,0)
+            @test_throws ArgumentError image_fun(T,nimages+1)
 
-                @testset "load single images" begin
-                    # Sample a few random images to compare
-                    for i = rand(1:nimages, 10)
-                        A_i = @inferred image_fun(T,i)
-                        @test typeof(A_i) <: Union{Array{T,2},Base.ReinterpretArray{T,2}}
-                        @test size(A_i) == (28,28)
-                        @test A_i == A[:,:,i]
-                    end
+            @testset "load single images" begin
+                # Sample a few random images to compare
+                for i = rand(1:nimages, 10)
+                    A_i = @inferred image_fun(T,i)
+                    @test A_i isa AbstractArray{T,2}
+                    @test size(A_i) == (28,28)
+                    @test A_i == A[:,:,i]
                 end
+            end
 
-                @testset "load multiple images" begin
-                    A_5_10 = @inferred image_fun(T,5:10)
-                    @test typeof(A_5_10) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test size(A_5_10) == (28,28,6)
-                    for i = 1:6
-                        @test A_5_10[:,:,i] == A[:,:,i+4]
-                    end
+            @testset "load multiple images" begin
+                A_5_10 = @inferred image_fun(T,5:10)
+                @test A_5_10 isa AbstractArray{T,3}
+                @test size(A_5_10) == (28,28,6)
+                @test A_5_10 == A[:,:,5:10]
 
-                    # also test edge cases `1`, `nimages`
-                    indices = [10,3,9,1,nimages]
-                    A_vec   = image_fun(T,indices)
-                    A_vec_f = image_fun(T,Vector{Int32}(indices))
-                    @test typeof(A_vec) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test typeof(A_vec_f) <: Union{Array{T,3},Base.ReinterpretArray{T,3}}
-                    @test size(A_vec)   == (28,28,5)
-                    @test size(A_vec_f) == (28,28,5)
-                    for i in 1:5
-                        @test A_vec[:,:,i] == A[:,:,indices[i]]
-                        @test A_vec[:,:,i] == A_vec_f[:,:,i]
-                    end
-                end
+                # also test edge cases `1`, `nimages`
+                indices = [10,3,9,1,nimages]
+                A_vec   = image_fun(T,indices)
+                A_vec_f = image_fun(T,Vector{Int32}(indices))
+                @test A_vec   isa AbstractArray{T,3}
+                @test A_vec_f isa AbstractArray{T,3}
+                @test size(A_vec)   == (28,28,5)
+                @test size(A_vec_f) == (28,28,5)
+                @test A_vec == A[:,:,indices]
+                @test A_vec == A_vec_f
             end
         end
     end
@@ -188,78 +184,72 @@ else
         # for a specific index.
         # -- However, technically these tests do not check if
         #    these are the actual MNIST labels of that index!
-        for (label_fun, nlabels) in
+        @testset "$label_fun" for (label_fun, nlabels) in
                     ((MNIST.trainlabels, 60_000),
                      (MNIST.testlabels,  10_000))
-            @testset "$label_fun" begin
-                # whole label set
-                A = @inferred label_fun()
-                @test typeof(A) <: Vector{Int64}
-                @test size(A) == (nlabels,)
+            # whole label set
+            A = @inferred label_fun()
+            @test A isa Vector{Int64}
+            @test size(A) == (nlabels,)
 
-                @testset "load single label" begin
-                    # Sample a few random labels to compare
-                    for i = rand(1:nlabels, 10)
-                        A_i = @inferred label_fun(i)
-                        @test typeof(A_i) <: Int64
-                        @test A_i == A[i]
-                    end
+            @testset "load single label" begin
+                # Sample a few random labels to compare
+                for i = rand(1:nlabels, 10)
+                    A_i = @inferred label_fun(i)
+                    @test A_i isa Int64
+                    @test A_i == A[i]
                 end
+            end
 
-                @testset "load multiple labels" begin
-                    A_5_10 = @inferred label_fun(5:10)
-                    @test typeof(A_5_10) <: Vector{Int64}
-                    @test size(A_5_10) == (6,)
-                    for i = 1:6
-                        @test A_5_10[i] == A[i+4]
-                    end
+            @testset "load multiple labels" begin
+                A_5_10 = @inferred label_fun(5:10)
+                @test A_5_10 isa Vector{Int64}
+                @test size(A_5_10) == (6,)
+                @test A_5_10 == A[5:10]
 
-                    # also test edge cases `1`, `nlabels`
-                    indices = [10,3,9,1,nlabels]
-                    A_vec   = @inferred label_fun(indices)
-                    A_vec_f = @inferred label_fun(Vector{Int32}(indices))
-                    @test typeof(A_vec)   <: Vector{Int64}
-                    @test typeof(A_vec_f) <: Vector{Int64}
-                    @test size(A_vec)   == (5,)
-                    @test size(A_vec_f) == (5,)
-                    for i in 1:5
-                        @test A_vec[i] == A[indices[i]]
-                        @test A_vec[i] == A_vec_f[i]
-                    end
-                end
+                # also test edge cases `1`, `nlabels`
+                indices = [10,3,9,1,nlabels]
+                A_vec   = @inferred label_fun(indices)
+                A_vec_f = @inferred label_fun(Vector{Int32}(indices))
+                @test A_vec   isa Vector{Int64}
+                @test A_vec_f isa Vector{Int64}
+                @test size(A_vec)   == (5,)
+                @test size(A_vec_f) == (5,)
+                @test A_vec == A[indices]
+                @test A_vec == A_vec_f
             end
         end
     end
 
     # Check against the already tested tensor and labels functions
     @testset "Data" begin
-        for (data_fun, feature_fun, label_fun, nobs) in
+        @testset "check $data_fun against $feature_fun and $label_fun" for
+            (data_fun, feature_fun, label_fun, nobs) in
                 ((MNIST.traindata, MNIST.traintensor, MNIST.trainlabels, 60_000),
                  (MNIST.testdata,  MNIST.testtensor,  MNIST.testlabels,  10_000))
-            @testset "check $data_fun against $feature_fun and $label_fun" begin
-                data, labels = @inferred data_fun()
-                @test data == @inferred feature_fun()
-                @test labels == @inferred label_fun()
 
-                for i = rand(1:nobs, 10)
-                    d_i, l_i = @inferred data_fun(i)
-                    @test d_i == @inferred feature_fun(i)
-                    @test l_i == @inferred label_fun(i)
-                end
+            data, labels = @inferred data_fun()
+            @test data == @inferred feature_fun()
+            @test labels == @inferred label_fun()
 
-                data, labels = @inferred data_fun(5:10)
-                @test data == @inferred feature_fun(5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                data, labels = @inferred data_fun(Int, 5:10)
-                @test data == @inferred feature_fun(Int, 5:10)
-                @test labels == @inferred label_fun(5:10)
-
-                indices = [10,3,9,1,nobs]
-                data, labels = @inferred data_fun(indices)
-                @test data == @inferred feature_fun(indices)
-                @test labels == @inferred label_fun(indices)
+            for i = rand(1:nobs, 10)
+                d_i, l_i = @inferred data_fun(i)
+                @test d_i == @inferred feature_fun(i)
+                @test l_i == @inferred label_fun(i)
             end
+
+            data, labels = @inferred data_fun(5:10)
+            @test data == @inferred feature_fun(5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            data, labels = @inferred data_fun(Int, 5:10)
+            @test data == @inferred feature_fun(Int, 5:10)
+            @test labels == @inferred label_fun(5:10)
+
+            indices = [10,3,9,1,nobs]
+            data, labels = @inferred data_fun(indices)
+            @test data == @inferred feature_fun(indices)
+            @test labels == @inferred label_fun(indices)
         end
     end
 end

--- a/test/tst_mnist.jl
+++ b/test/tst_mnist.jl
@@ -52,9 +52,6 @@ end
 
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
-if isCI()
-    @info "CI detected: skipping dataset download"
-else
     data_dir = withenv("DATADEPS_ALWAYS_ACCEPT"=>"true") do
         datadep"MNIST"
     end
@@ -252,6 +249,5 @@ else
             @test labels == @inferred label_fun(indices)
         end
     end
-end
 
 end

--- a/test/tst_mnist.jl
+++ b/test/tst_mnist.jl
@@ -143,13 +143,13 @@ end
                 @test A_5_10 == A[:,:,5:10]
 
                 # also test edge cases `1`, `nimages`
-                indices = [10,3,9,1,nimages]
+                indices = [10,1,3,3,9,1,nimages]
                 A_vec   = image_fun(T,indices)
                 A_vec_f = image_fun(T,Vector{Int32}(indices))
                 @test A_vec   isa AbstractArray{T,3}
                 @test A_vec_f isa AbstractArray{T,3}
-                @test size(A_vec)   == (28,28,5)
-                @test size(A_vec_f) == (28,28,5)
+                @test size(A_vec)   == (28,28,7)
+                @test size(A_vec_f) == (28,28,7)
                 @test A_vec == A[:,:,indices]
                 @test A_vec == A_vec_f
             end
@@ -205,13 +205,13 @@ end
                 @test A_5_10 == A[5:10]
 
                 # also test edge cases `1`, `nlabels`
-                indices = [10,3,9,1,nlabels]
+                indices = [10,1,3,3,9,1,nlabels]
                 A_vec   = @inferred label_fun(indices)
                 A_vec_f = @inferred label_fun(Vector{Int32}(indices))
                 @test A_vec   isa Vector{Int64}
                 @test A_vec_f isa Vector{Int64}
-                @test size(A_vec)   == (5,)
-                @test size(A_vec_f) == (5,)
+                @test size(A_vec)   == (7,)
+                @test size(A_vec_f) == (7,)
                 @test A_vec == A[indices]
                 @test A_vec == A_vec_f
             end
@@ -243,7 +243,7 @@ end
             @test data == @inferred feature_fun(Int, 5:10)
             @test labels == @inferred label_fun(5:10)
 
-            indices = [10,3,9,1,nobs]
+            indices = [10,1,3,3,9,1,nobs]
             data, labels = @inferred data_fun(indices)
             @test data == @inferred feature_fun(indices)
             @test labels == @inferred label_fun(indices)

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -133,13 +133,13 @@ else
                 end
 
                 # also test edge cases `1`, `nimages`
-                indices = [10,3,9,1,nimages]
+                indices = [10,1,3,3,9,1,nimages]
                 A_vec   = image_fun(T,indices)
                 A_vec_f = image_fun(T,Vector{Int32}(indices))
                 @test A_vec   isa AbstractArray{T,4}
                 @test A_vec_f isa AbstractArray{T,4}
-                @test size(A_vec)   == (32,32,3,5)
-                @test size(A_vec_f) == (32,32,3,5)
+                @test size(A_vec)   == (32,32,3,7)
+                @test size(A_vec_f) == (32,32,3,7)
                 @test A_vec == A[:,:,:,indices]
                 @test A_vec == A_vec_f
             end
@@ -202,13 +202,13 @@ else
                 @test A_5_10 == A[5:10]
 
                 # also test edge cases `1`, `nlabels`
-                indices = [10,3,9,1,nlabels]
+                indices = [10,1,3,3,9,1,nlabels]
                 A_vec   = @inferred label_fun(indices)
                 A_vec_f = @inferred label_fun(Vector{Int32}(indices))
                 @test A_vec   isa Vector{Int64}
                 @test A_vec_f isa Vector{Int64}
-                @test size(A_vec)   == (5,)
-                @test size(A_vec_f) == (5,)
+                @test size(A_vec)   == (7,)
+                @test size(A_vec_f) == (7,)
                 @test A_vec == A[indices]
                 @test A_vec == A_vec_f
             end
@@ -239,7 +239,7 @@ else
             @test data == @inferred feature_fun(Int, 5:10)
             @test labels == @inferred label_fun(5:10)
 
-            indices = [10,3,9,1,nobs]
+            indices = [10,1,3,3,9,1,nobs]
             data, labels = @inferred data_fun(indices)
             @test data == @inferred feature_fun(indices)
             @test labels == @inferred label_fun(indices)


### PR DESCRIPTION
This PR drops Julia v0.6 and fixes most of Julia v0.7/v1.0 deprecations. Plus it does a few other things:
* switches to [CodecZlib.jl](https://github.com/bicycle1885/CodecZlib.jl) from the aging GZip.jl. Unfortunately, it required much more refactoring of the reading code than I originally anticipated (since CodecZlib doesn't support `seek()`). But hopefully these changes simplify the codebase a bit too.
* makes ImageCore.jl and MAT.jl optional (via [Requires.jl](https://github.com/MikeInnes/Requires.jl)). These packages bring with them tons of other dependencies, while the functionality they provide is not essential. ImageCore and MAT are still required for the unit testing. If you install ImageCore and/or MAT in your julia environment, the corresponding MLDatasets functions (converting to images and SVHN2 dataset) would be automatically enabled.
* updates UD_English links