### PR TITLE
Make ImageCore and MAT packages optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
 
 after_success:
   - julia -e 'using Pkg, MLDatasets; cd(joinpath(dirname(pathof(MLDatasets)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-  - julie -e 'using Pkg; Pkg.add("Documenter"); cd(joinpath(dirname(pathof(MLDatasets)), "..")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg, MLDatasets; Pkg.add("Documenter"); cd(joinpath(dirname(pathof(MLDatasets)), "..")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,7 @@
 julia 0.7
-ImageCore 0.1.2
+Requires
 FixedPointNumbers 0.3
 ColorTypes 0.4
 DataDeps 0.3
-GZip
+GZip 0.5
 BinDeps
-MAT

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,7 +30,7 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaML/MLDatasets.jl.git",
     target = "build",
-    julia = "0.6",
+    julia = "0.7",
     deps = nothing,
     make = nothing,
 )

--- a/docs/src/LICENSE.md
+++ b/docs/src/LICENSE.md
@@ -1,5 +1,6 @@
 # LICENSE
 
 ```@eval
-Markdown.parse_file(joinpath(@__DIR__, "../LICENSE"))
+using Markdown
+Markdown.parse_file(joinpath(@__DIR__, "..", "..", "LICENSE"))
 ```

--- a/src/CIFAR10/CIFAR10.jl
+++ b/src/CIFAR10/CIFAR10.jl
@@ -2,10 +2,10 @@ export CIFAR10
 module CIFAR10
     using DataDeps
     using BinDeps
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring,
+                        _colorview, _channelview
 
     export
 

--- a/src/CIFAR10/utils.jl
+++ b/src/CIFAR10/utils.jl
@@ -29,10 +29,10 @@ function convert2features(array::AbstractArray{<:Number,4})
 end
 
 convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(channelview(array), (3,2,1)))
+    convert2features(permutedims(_channelview(array), (3,2,1)))
 
 convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(channelview(array), (3,2,1,4)))
+    convert2features(permutedims(_channelview(array), (3,2,1,4)))
 
 """
     convert2image(array) -> Array{RGB}
@@ -68,13 +68,13 @@ end
 function convert2image(array::AbstractArray{<:Number,3})
     nrows, ncols, nchan = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,2,1)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,2,1)))
 end
 
 function convert2image(array::AbstractArray{<:Number,4})
     nrows, ncols, nchan, nimages = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,2,1,4)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,2,1,4)))
 end
 
 _norm_array(array::AbstractArray) = array

--- a/src/CIFAR100/CIFAR100.jl
+++ b/src/CIFAR100/CIFAR100.jl
@@ -4,7 +4,7 @@ module CIFAR100
     using BinDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
-    import ..CIFAR10: convert2image, convert2features
+    using ..CIFAR10: convert2image, convert2features
 
     export
 

--- a/src/FashionMNIST/FashionMNIST.jl
+++ b/src/FashionMNIST/FashionMNIST.jl
@@ -27,8 +27,8 @@ module FashionMNIST
     using DataDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
-    import ..MNIST: convert2image, convert2features
-    import ..MNIST.Reader
+    using ..MNIST: convert2image, convert2features
+    using ..MNIST.Reader
 
     export
 

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -1,12 +1,41 @@
 module MLDatasets
 
-using FixedPointNumbers
+using Requires
+using FixedPointNumbers, ColorTypes
 
 bytes_to_type(::Type{UInt8}, A::Array{UInt8}) = A
 bytes_to_type(::Type{N0f8}, A::Array{UInt8}) = reinterpret(N0f8, A)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:Integer = convert(Array{T}, A)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:AbstractFloat = A ./ T(255)
 bytes_to_type(::Type{T}, A::Array{UInt8}) where T<:Number  = convert(Array{T}, reinterpret(N0f8, A))
+
+global __images_supported__ = false
+global __matfiles_supported__ = false
+
+function _channelview(image::AbstractArray{<:Color})
+    __images_supported__ ||
+        error("Converting to/from image requires ImageCore package.")
+    channelview(image)
+end
+
+function _colorview(::Type{T}, array::AbstractArray{<:Number}) where T <: Color
+    __images_supported__ ||
+        error("Converting to image requires ImageCore package.")
+    colorview(T, array)
+end
+
+function _matopen(f::Function, path::AbstractString)
+    __matfiles_supported__ ||
+        error("Reading .mat files requires MAT package.")
+    matopen(f, path)
+end
+
+function _matread(path::AbstractString)
+    __matfiles_supported__ ||
+        error("Reading .mat files requires MAT package.")
+    matread(path)
+end
+
 
 include("download.jl")
 include("CoNLL.jl")
@@ -18,5 +47,17 @@ include("FashionMNIST/FashionMNIST.jl")
 include("SVHN2/SVHN2.jl")
 include("PTBLM/PTBLM.jl")
 include("UD_English/UD_English.jl")
+
+function __init__()
+    # initialize optional dependencies
+    @require ImageCore="a09fc81d-aa75-5fe9-8630-4744c3626534" begin
+        using ImageCore
+        global __images_supported__ = true
+    end
+    @require MAT="23992714-dd62-5051-b70f-ba57cb901cac" begin
+        using MAT
+        global __matfiles_supported__ = true
+    end
+end
 
 end

--- a/src/MNIST/MNIST.jl
+++ b/src/MNIST/MNIST.jl
@@ -25,10 +25,10 @@ the 10 possible digits (0-9).
 """
 module MNIST
     using DataDeps
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring,
+                        _colorview
 
     export
 

--- a/src/MNIST/utils.jl
+++ b/src/MNIST/utils.jl
@@ -55,9 +55,9 @@ function convert2image(array::AbstractMatrix{T}) where {T<:Number}
     if size(array) == (28, 28)
         # simple check to see if values are normalized to [0,1]
         if any(x->x > 50, array)
-            colorview(Gray, T(1) .- transpose(array) ./ T(255))
+            _colorview(Gray, T(1) .- transpose(array) ./ T(255))
         else
-            colorview(Gray, T(1) .- transpose(array))
+            _colorview(Gray, T(1) .- transpose(array))
         end
     else # feature matrix
         @assert size(array, 1) == 784
@@ -71,8 +71,8 @@ function convert2image(array::AbstractArray{T,3}) where {T<:Number}
     @assert h == 28 && w == 28
     # simple check to see if values are normalized to [0,1]
     if any(x->x > 50, array)
-        colorview(Gray, permutedims(T(1) .- array ./ T(255), [2,1,3]))
+        _colorview(Gray, permutedims(T(1) .- array ./ T(255), [2,1,3]))
     else
-        colorview(Gray, permutedims(T(1) .- array, [2,1,3]))
+        _colorview(Gray, permutedims(T(1) .- array, [2,1,3]))
     end
 end

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -30,11 +30,10 @@ additional to use as extra training data.
 """
 module SVHN2
     using DataDeps
-    using MAT
-    using ImageCore
     using ColorTypes
     using FixedPointNumbers
-    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring,
+                        _colorview, _channelview, _matopen, _matread
 
     export
 

--- a/src/SVHN2/interface.jl
+++ b/src/SVHN2/interface.jl
@@ -75,7 +75,7 @@ for (FUN, PATH, COUNT, DESC) in (
 
         function ($FUN)(::Type{T}; dir = nothing) where T
             path = datafile(DEPNAME, $PATH, dir)
-            images = matopen(io->read(io, "X"), path)::Array{UInt8,4}
+            images = _matopen(io->read(io, "X"), path)::Array{UInt8,4}
             bytes_to_type(T, images)
         end
 
@@ -123,7 +123,7 @@ for (FUN, PATH, COUNT, DESC) in (
         """
         function ($FUN)(; dir = nothing)
             path = datafile(DEPNAME, $PATH, dir)
-            labels = matopen(io->read(io, "y"), path)
+            labels = _matopen(io->read(io, "y"), path)
             Vector{Int}(vec(labels))::Vector{Int}
         end
 
@@ -183,7 +183,7 @@ for (FUN, PATH, DESC) in (
 
         function ($FUN)(::Type{T}; dir = nothing) where T
             path = datafile(DEPNAME, $PATH, dir)
-            vars = matread(path)
+            vars = _matread(path)
             images = vars["X"]::Array{UInt8,4}
             labels = vars["y"]
             bytes_to_type(T, images), Vector{Int}(vec(labels))::Vector{Int}

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -29,10 +29,10 @@ function convert2features(array::AbstractArray{<:Number,4})
 end
 
 convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(channelview(array), (2,3,1)))
+    convert2features(permutedims(_channelview(array), (2,3,1)))
 
 convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(channelview(array), (2,3,1,4)))
+    convert2features(permutedims(_channelview(array), (2,3,1,4)))
 
 """
     convert2image(array) -> Array{RGB}
@@ -68,13 +68,13 @@ end
 function convert2image(array::AbstractArray{<:Number,3})
     nrows, ncols, nchan = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,1,2)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,1,2)))
 end
 
 function convert2image(array::AbstractArray{<:Number,4})
     nrows, ncols, nchan, nimages = size(array)
     @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    colorview(RGB, permutedims(_norm_array(array), (3,1,2,4)))
+    _colorview(RGB, permutedims(_norm_array(array), (3,1,2,4)))
 end
 
 _norm_array(array::AbstractArray) = array

--- a/src/download.jl
+++ b/src/download.jl
@@ -31,12 +31,12 @@ end
 function datafile(depname, filename, dir = nothing; recurse = true, kw...)
     path = joinpath(datadir(depname, dir; kw...), filename)
     if !isfile(path)
-        warn("The file \"$path\" does not exist, even though the dataset-specific folder does. This is an unusual situation that may have been caused by a manual creation of an empty folder, or manual deletion of the given file \"$filename\".")
+        @warn "The file \"$path\" does not exist, even though the dataset-specific folder does. This is an unusual situation that may have been caused by a manual creation of an empty folder, or manual deletion of the given file \"$filename\"."
         if dir == nothing
-            info("Retriggering DataDeps.jl for \"$depname\"")
+            @info "Retriggering DataDeps.jl for \"$depname\""
             download_dep(depname; kw...)
         else
-            info("Retriggering DataDeps.jl for \"$depname\" to \"$dir\".")
+            @info "Retriggering DataDeps.jl for \"$depname\" to \"$dir\"."
             download_dep(depname, dir; kw...)
         end
         if recurse

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+ImageCore 0.7
+MAT 0.4

--- a/test/tst_cifar10.jl
+++ b/test/tst_cifar10.jl
@@ -58,7 +58,7 @@ end
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
 if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+    @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"CIFAR10"

--- a/test/tst_cifar100.jl
+++ b/test/tst_cifar100.jl
@@ -29,7 +29,7 @@ end
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
 if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+    @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"CIFAR100"

--- a/test/tst_fashion_mnist.jl
+++ b/test/tst_fashion_mnist.jl
@@ -28,7 +28,7 @@ end
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
 if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+    @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"FashionMNIST"

--- a/test/tst_mnist.jl
+++ b/test/tst_mnist.jl
@@ -51,7 +51,7 @@ end
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
 if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+    @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"MNIST"

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -53,7 +53,7 @@ end
 # NOT executed on CI. only executed locally.
 # This involves dataset download etc.
 if parse(Bool, get(ENV, "CI", "false"))
-    info("CI detected: skipping dataset download")
+    @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
         datadep"SVHN2"

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -5,6 +5,7 @@ using ImageCore
 using FixedPointNumbers
 using MLDatasets
 using DataDeps
+using MAT
 
 @testset "Constants" begin
     @test SVHN2.classnames() isa Vector{Int}


### PR DESCRIPTION
This PR (extracted from #20) makes ImageCore.jl and MAT.jl packages optional (via [Requires.jl](https://github.com/MikeInnes/Requires.jl)). These packages bring with them tons of other dependencies, while the functionality they provide is not essential. ImageCore and MAT are still required for unit testing. If ImageCore and/or MAT are added to a specific Julia project, the corresponding MLDatasets functions (converting to images and SVHN2 dataset) would be automatically enabled.

As a samll added bonus it should fix Documenter scripts.