### PR TITLE
move with_accept() to download_dep()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ jobs:
         - julia -e 'import MLDatasets; ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs","make.jl"))'
 
 ## uncomment the following lines to override the default test script
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.add(pwd()); Pkg.build("MLDatasets"); Pkg.test("MLDatasets"; coverage=true)';
+#script:
+#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#    - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.add(pwd()); Pkg.build("MLDatasets"); Pkg.test("MLDatasets"; coverage=true)';
 
 after_success:
 - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'


### PR DESCRIPTION
I think `with_accept()` should be in `download_dep()` rather than `datadir()`.
Otherwise e.g. `MNIST.download(i_accept_the_terms_of_use = true)` has no chances of setting `DATADEPS_ALWAYS_ACCEPT`.