### PR TITLE
return image tensors in WH format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MLDatasets"
 uuid = "eb30cadb-4394-5ae3-aed4-317e484a6458"
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
@@ -12,13 +12,13 @@ GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-ColorTypes = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+BinDeps = "1"
+ColorTypes = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
 DataDeps = "0.3, 0.4, 0.5, 0.6, 0.7"
 FixedPointNumbers = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
-ImageCore = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
 GZip = "0.5"
+ImageCore = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
 Requires = "1"
-BinDeps = "1"
 julia = "1"
 
 [extras]

--- a/docs/src/datasets/CIFAR10.md
+++ b/docs/src/datasets/CIFAR10.md
@@ -56,21 +56,8 @@ the CIFAR-10 dataset in Julia more convenient.
 
 Function | Description
 ---------|-------------
-[`convert2features(array)`](@ref CIFAR10.convert2features) | Convert the CIFAR-10 tensor to a flat feature matrix
 [`convert2image(array)`](@ref CIFAR10.convert2image) | Convert the CIFAR-10 tensor/matrix to a colorant array
 
-You can use the function
-[`convert2features`](@ref CIFAR10.convert2features) to convert
-the given CIFAR-10 tensor to a feature matrix (or feature vector
-in the case of a single image). The purpose of this function is
-to drop the spatial dimensions such that traditional ML
-algorithms can process the dataset.
-
-```julia
-julia> CIFAR10.convert2features(CIFAR10.traintensor()) # full training data
-3072×50000 Array{N0f8,2}:
-[...]
-```
 
 To visualize an image or a prediction we provide the function
 [`convert2image`](@ref CIFAR10.convert2image) to convert the
@@ -106,7 +93,6 @@ CIFAR10.testdata
 ```@docs
 CIFAR10.download
 CIFAR10.classnames
-CIFAR10.convert2features
 CIFAR10.convert2image
 ```
 

--- a/docs/src/datasets/CIFAR100.md
+++ b/docs/src/datasets/CIFAR100.md
@@ -60,21 +60,8 @@ the CIFAR-100 dataset in Julia more convenient.
 
 Function | Description
 ---------|-------------
-[`convert2features(array)`](@ref CIFAR10.convert2features) | Convert the CIFAR-100 tensor to a flat feature matrix
 [`convert2image(array)`](@ref CIFAR10.convert2image) | Convert the CIFAR-100 tensor/matrix to a colorant array
 
-You can use the function
-[`convert2features`](@ref CIFAR10.convert2features) to convert
-the given CIFAR-100 tensor to a feature matrix (or feature vector
-in the case of a single image). The purpose of this function is
-to drop the spatial dimensions such that traditional ML
-algorithms can process the dataset.
-
-```julia
-julia> CIFAR100.convert2features(CIFAR100.traintensor()) # full training data
-3072×50000 Array{N0f8,2}:
-[...]
-```
 
 To visualize an image or a prediction we provide the function
 [`convert2image`](@ref CIFAR10.convert2image) to convert the
@@ -107,14 +94,14 @@ CIFAR100.testdata
 
 ### Utilities
 
-See [`CIFAR10.convert2features`](@ref) and
-[`CIFAR10.convert2image`](@ref)
 
 ```@docs
 CIFAR100.download
 CIFAR100.classnames_coarse
 CIFAR100.classnames_fine
 ```
+
+See also [`CIFAR10.convert2image`](@ref).
 
 ## References
 

--- a/docs/src/datasets/FashionMNIST.md
+++ b/docs/src/datasets/FashionMNIST.md
@@ -56,21 +56,7 @@ the Fashion-MNIST dataset in Julia more convenient.
 
 Function | Description
 ---------|-------------
-[`convert2features(array)`](@ref MNIST.convert2features) | Convert the Fashion-MNIST tensor to a flat feature matrix
 [`convert2image(array)`](@ref MNIST.convert2image) | Convert the Fashion-MNIST tensor/matrix to a colorant array
-
-You can use the function
-[`convert2features`](@ref MNIST.convert2features) to
-convert the given Fashion-MNIST tensor to a feature matrix (or
-feature vector in the case of a single image). The purpose of
-this function is to drop the spatial dimensions such that
-traditional ML algorithms can process the dataset.
-
-```julia
-julia> FashionMNIST.convert2features(FashionMNIST.traintensor()) # full training data
-784×60000 Array{N0f8,2}:
-[...]
-```
 
 To visualize an image or a prediction we provide the function
 [`convert2image`](@ref MNIST.convert2image) to convert the
@@ -114,8 +100,7 @@ FashionMNIST.download
 FashionMNIST.classnames
 ```
 
-Also, the `FashionMNIST` module is re-exporting [`convert2features`](@ref MNIST.convert2features)
-and [`convert2image`](@ref MNIST.convert2image) from the [`MNIST`](@ref) module.
+Also, the `FashionMNIST` module is re-exporting [`convert2image`](@ref MNIST.convert2image) from the [`MNIST`](@ref) module.
 
 ## References
 

--- a/docs/src/datasets/MNIST.md
+++ b/docs/src/datasets/MNIST.md
@@ -56,20 +56,7 @@ the MNIST dataset in Julia more convenient.
 
 Function | Description
 ---------|-------------
-[`convert2features(array)`](@ref MNIST.convert2features) | Convert the MNIST tensor to a flat feature matrix
 [`convert2image(array)`](@ref MNIST.convert2image) | Convert the MNIST tensor/matrix to a colorant array
-
-You can use the function [`convert2features`](@ref
-MNIST.convert2features) to convert the given MNIST tensor to a
-feature matrix (or feature vector in the case of a single image).
-The purpose of this function is to drop the spatial dimensions
-such that traditional ML algorithms can process the dataset.
-
-```julia
-julia> MNIST.convert2features(MNIST.traintensor()) # full training data
-784×60000 Array{N0f8,2}:
-[...]
-```
 
 To visualize an image or a prediction we provide the function
 [`convert2image`](@ref MNIST.convert2image) to convert the given
@@ -110,7 +97,6 @@ MNIST.testdata
 
 ```@docs
 MNIST.download
-MNIST.convert2features
 MNIST.convert2image
 ```
 

--- a/docs/src/datasets/SVHN2.md
+++ b/docs/src/datasets/SVHN2.md
@@ -77,21 +77,7 @@ the SVHN (format 2) dataset in Julia more convenient.
 
 Function | Description
 ---------|-------------
-[`convert2features(array)`](@ref SVHN2.convert2features) | Convert the SVHN tensor to a flat feature matrix
 [`convert2image(array)`](@ref SVHN2.convert2image) | Convert the SVHN tensor/matrix to a colorant array
-
-You can use the function
-[`convert2features`](@ref SVHN2.convert2features) to convert
-the given SVHN tensor to a feature matrix (or feature vector
-in the case of a single image). The purpose of this function is
-to drop the spatial dimensions such that traditional ML
-algorithms can process the dataset.
-
-```julia
-julia> SVHN2.convert2features(SVHN2.traindata()[1]) # full training data
-3072×73257 Array{N0f8,2}:
-[...]
-```
 
 To visualize an image or a prediction we provide the function
 [`convert2image`](@ref SVHN2.convert2image) to convert the
@@ -139,7 +125,6 @@ SVHN2.extradata
 ```@docs
 SVHN2.download
 SVHN2.classnames
-SVHN2.convert2features
 SVHN2.convert2image
 ```
 

--- a/src/CIFAR10/CIFAR10.jl
+++ b/src/CIFAR10/CIFAR10.jl
@@ -21,7 +21,6 @@ module CIFAR10
         testdata,
 
         convert2image,
-        convert2features,
 
         download
 

--- a/src/CIFAR10/interface.jl
+++ b/src/CIFAR10/interface.jl
@@ -13,15 +13,15 @@ given `indices` as a multi-dimensional array of eltype `T`. If
 the corresponding labels are required as well, it is recommended
 to use [`CIFAR10.traindata`](@ref) instead.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 4D array (i.e. a `Array{T,4}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, the third dimension the RGB color channels, and the fourth
 dimension denotes the index of the image.
 
@@ -35,11 +35,8 @@ julia> CIFAR10.traintensor(Float32, 1:3) # first three images as Float32
 [...]
 ```
 
-If `indices` is an `Integer`, the single image is returned as
-`Array{T,3}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), the second
-dimension denotes the pixel *columns* (y), and the third
-dimension the RGB color channels of the image.
+If `indices` is an `Integer`, a single image is returned as
+`Array{T,3}` array. 
 
 ```julia-repl
 julia> CIFAR10.traintensor(1) # load first training image
@@ -47,9 +44,7 @@ julia> CIFAR10.traintensor(1) # load first training image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an CIFAR-10 array into a
 vertical-major Julia image with the appropriate `RGB` eltype.
 
@@ -78,15 +73,15 @@ Return the CIFAR-10 **test** images corresponding to the given
 corresponding labels are required as well, it is recommended to
 use [`CIFAR10.testdata`](@ref) instead.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 4D array (i.e. a `Array{T,4}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, the third dimension the RGB color channels, and the fourth
 dimension denotes the index of the image.
 
@@ -100,11 +95,8 @@ julia> CIFAR10.testtensor(Float32, 1:3) # first three images as Float32
 [...]
 ```
 
-If `indices` is an `Integer`, the single image is returned as
-`Array{T,3}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), the second
-dimension denotes the pixel *columns* (y), and the third
-dimension the RGB color channels of the image.
+If `indices` is an `Integer`, a single image is returned as
+`Array{T,3}`.
 
 ```julia-repl
 julia> CIFAR10.testtensor(1) # load first training image
@@ -112,9 +104,7 @@ julia> CIFAR10.testtensor(1) # load first training image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an CIFAR-10 array into a
 vertical-major Julia image with the appropriate `RGB` eltype.
 
@@ -217,7 +207,7 @@ full trainingset is returned. The first element of the return
 values will be the images as a multi-dimensional array, and the
 second element the corresponding labels as integers.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer
@@ -257,6 +247,7 @@ function traindata(::Type{T}; dir = nothing) where T
     # and one label array. (good enough)
     images = cat(Xs..., dims=4)::Array{UInt8,4}
     labels = vcat(Ys...)::Vector{Int}
+    images = permutedims(images, (2, 1, 3, 4))
     # optionally transform the image array before returning
     bytes_to_type(T, images), labels
 end
@@ -273,6 +264,7 @@ function traindata(::Type{T}, index::Integer; dir = nothing) where T
     sub_index = ((index - 1) % Reader.CHUNK_SIZE) + 1
     image, label = Reader.readdata(file_path, sub_index)
     # optionally transform the image array before returning
+    image = permutedims(image, (2, 1, 3))
     bytes_to_type(T, image), label
 end
 
@@ -309,6 +301,7 @@ function traindata(::Type{T}, indices::AbstractVector; dir = nothing) where T
             end
         end
     end
+    images = permutedims(images, (2, 1, 3, 4))
     # optionally transform the image array before returning
     bytes_to_type(T, images::Array{UInt8,4}), labels::Vector{Int}
 end
@@ -322,7 +315,7 @@ full testset is returned. The first element of the return
 values will be the images as a multi-dimensional array, and the
 second element the corresponding labels as integers.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer
@@ -348,6 +341,7 @@ function testdata(::Type{T}; dir = nothing) where T
     file_path = datafile(DEPNAME, TESTSET_FILENAME, dir)
     # simply read the complete content of the testset file
     images, labels = Reader.readdata(file_path)
+    images = permutedims(images, (2, 1, 3, 4))
     # optionally transform the image array before returning
     bytes_to_type(T, images), labels
 end
@@ -357,6 +351,7 @@ function testdata(::Type{T}, index::Integer; dir = nothing) where T
     file_path = datafile(DEPNAME, TESTSET_FILENAME, dir)
     # read the single image+label corresponding to "index"
     image, label = Reader.readdata(file_path, index)
+    image = permutedims(image, (2, 1, 3))
     # optionally transform the image array before returning
     bytes_to_type(T, image), label
 end
@@ -387,5 +382,6 @@ function testdata(::Type{T}, indices::AbstractVector; dir = nothing) where T
         end
     end
     # optionally transform the image array before returning
+    images = permutedims(images, (2, 1, 3, 4))
     bytes_to_type(T, images::Array{UInt8,4}), labels::Vector{Int}
 end

--- a/src/CIFAR10/utils.jl
+++ b/src/CIFAR10/utils.jl
@@ -1,80 +1,29 @@
 """
-    convert2features(array)
-
-Convert the given CIFAR-10 tensor to a feature matrix (or feature
-vector in the case of a single image). The purpose of this
-function is to drop the spatial dimensions such that traditional
-ML algorithms can process the dataset.
-
-```julia
-julia> CIFAR10.convert2features(CIFAR10.traintensor(Float32)) # full training data
-3072×50000 Array{Float32,2}:
-[...]
-
-julia> CIFAR10.convert2features(CIFAR10.traintensor(Float32,1)) # first observation
-3072-element Array{Float32,1}:
-[...]
-```
-"""
-function convert2features(array::AbstractArray{<:Number,3})
-    nrows, ncols, nchan = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    vec(array)
-end
-
-function convert2features(array::AbstractArray{<:Number,4})
-    nrows, ncols, nchan, nimages = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    reshape(array, (nrows * ncols * nchan, nimages))
-end
-
-convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(_channelview(array), (3,2,1)))
-
-convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(_channelview(array), (3,2,1,4)))
-
-"""
     convert2image(array) -> Array{RGB}
 
-Convert the given CIFAR-10 horizontal-major tensor (or feature
+Convert the given CIFAR-10 vertical-major tensor (or feature
 vector/matrix) to a vertical-major `RGB` array.
 
-```julia
+```julia                                                                                                                                                                                                                                                                                    
 julia> CIFAR10.convert2image(CIFAR10.traintensor()) # full training dataset
 32×32×50000 Array{RGB{N0f8},3}:
-[...]
+[...]                                                                                                                                                                                                                                                                             
 
 julia> CIFAR10.convert2image(CIFAR10.traintensor(1)) # first training image
 32×32 Array{RGB{N0f8},2}:
 [...]
-```
+```                                                                                                                                                                                                                                                                                 
 """
-function convert2image(array::AbstractVector{<:Number})
-    @assert length(array) % 3072 == 0
-    if length(array) == 3072
-        convert2image(reshape(array, 32, 32, 3))
-    else
-        n = Int(length(array) / 3072)
-        convert2image(reshape(array, 32, 32, 3, n))
-    end
-end
-
-function convert2image(array::AbstractMatrix{<:Number})
-    @assert size(array, 1) == 3072
-    convert2image(reshape(array, 32, 32, 3, size(array, 2)))
-end
-
-function convert2image(array::AbstractArray{<:Number,3})
-    nrows, ncols, nchan = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    _colorview(RGB, permutedims(_norm_array(array), (3,2,1)))
-end
-
-function convert2image(array::AbstractArray{<:Number,4})
-    nrows, ncols, nchan, nimages = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    _colorview(RGB, permutedims(_norm_array(array), (3,2,1,4)))
+function convert2image(array::AbstractArray{T}) where {T<:Number}
+    nlast = size(array)[end] 
+    array = reshape(                                                                                                                                                                                                                                                                                    array, 32, 32, 3, :)
+    array = permutedims(array, (3, 1, 2, 4))
+    if size(array)[end] == 1 && nlast != 1
+        array = dropdims(array, dims=4)
+    end                                                                                                                                                                                                                                                                                 
+    img = _colorview(RGB, _norm_array(array))
+ 
+    img
 end
 
 _norm_array(array::AbstractArray) = array

--- a/src/CIFAR100/CIFAR100.jl
+++ b/src/CIFAR100/CIFAR100.jl
@@ -4,7 +4,7 @@ module CIFAR100
     using BinDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
-    using ..CIFAR10: convert2image, convert2features
+    using ..CIFAR10: convert2image
 
     export
 
@@ -21,7 +21,6 @@ module CIFAR100
         testdata,
 
         convert2image,
-        convert2features,
 
         download
 

--- a/src/CIFAR100/interface.jl
+++ b/src/CIFAR100/interface.jl
@@ -34,15 +34,15 @@ given `indices` as a multi-dimensional array of eltype `T`. If
 the corresponding labels are required as well, it is recommended
 to use [`CIFAR100.traindata`](@ref) instead.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the native vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 4D array (i.e. a `Array{T,4}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, the third dimension the RGB color channels, and the fourth
 dimension denotes the index of the image.
 
@@ -57,10 +57,7 @@ julia> CIFAR100.traintensor(Float32, 1:3) # first three images as Float32
 ```
 
 If `indices` is an `Integer`, the single image is returned as
-`Array{T,3}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), the second
-dimension denotes the pixel *columns* (y), and the third
-dimension the RGB color channels of the image.
+`Array{T,3}`.
 
 ```julia-repl
 julia> CIFAR100.traintensor(1) # load first training image
@@ -68,9 +65,7 @@ julia> CIFAR100.traintensor(1) # load first training image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an CIFAR-100 array into a
 vertical-major Julia image with the appropriate `RGB` eltype.
 
@@ -99,15 +94,15 @@ Return the CIFAR-100 **test** images corresponding to the given
 corresponding labels are required as well, it is recommended to
 use [`CIFAR100.testdata`](@ref) instead.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the native vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 4D array (i.e. a `Array{T,4}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, the third dimension the RGB color channels, and the fourth
 dimension denotes the index of the image.
 
@@ -122,10 +117,7 @@ julia> CIFAR100.testtensor(Float32, 1:3) # first three images as Float32
 ```
 
 If `indices` is an `Integer`, the single image is returned as
-`Array{T,3}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), the second
-dimension denotes the pixel *columns* (y), and the third
-dimension the RGB color channels of the image.
+`Array{T,3}`.
 
 ```julia-repl
 julia> CIFAR100.testtensor(1) # load first training image
@@ -133,9 +125,7 @@ julia> CIFAR100.testtensor(1) # load first training image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an CIFAR-100 array into a
 vertical-major Julia image with the appropriate `RGB` eltype.
 
@@ -242,7 +232,7 @@ array, the second element (`Yc`) the corresponding coarse labels
 as integers, and the third element (`Yf`) the fine labels
 respectively.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the native vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer
@@ -268,6 +258,8 @@ function traindata(::Type{T}; dir = nothing) where T
     file_path = datafile(DEPNAME, TRAINSET_FILENAME, dir)
     # simply read the complete content of the testset file
     images, labels_c, labels_f = Reader.readdata(file_path, TRAINSET_SIZE)
+    images = permutedims(images, (2, 1, 3, 4))
+    
     # optionally transform the image array before returning
     bytes_to_type(T, images), labels_c, labels_f
 end
@@ -277,6 +269,7 @@ function traindata(::Type{T}, index::Integer; dir = nothing) where T
     file_path = datafile(DEPNAME, TRAINSET_FILENAME, dir)
     # read the single image+labelc+labelf corresponding to "index"
     image, label_c, label_f = Reader.readdata(file_path, TRAINSET_SIZE, index)
+    image = permutedims(image, (2, 1, 3))
     # optionally transform the image array before returning
     bytes_to_type(T, image), label_c, label_f
 end
@@ -308,6 +301,8 @@ function traindata(::Type{T}, indices::AbstractVector; dir = nothing) where T
             labels_f[i] = yf
         end
     end
+    images = permutedims(images, (2, 1, 3, 4))
+    
     # optionally transform the image array before returning
     bytes_to_type(T, images::Array{UInt8,4}), labels_c::Vector{Int}, labels_f::Vector{Int}
 end
@@ -323,7 +318,7 @@ second element (`Yc`) the corresponding coarse labels as
 integers, and the third element (`Yf`) the fine labels
 respectively.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the native vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer
@@ -350,6 +345,7 @@ function testdata(::Type{T}; dir = nothing) where T
     # simply read the complete content of the testset file
     images, labels_c, labels_f = Reader.readdata(file_path, TESTSET_SIZE)
     # optionally transform the image array before returning
+    images = permutedims(images, (2, 1, 3, 4))    
     bytes_to_type(T, images), labels_c, labels_f
 end
 
@@ -358,6 +354,7 @@ function testdata(::Type{T}, index::Integer; dir = nothing) where T
     file_path = datafile(DEPNAME, TESTSET_FILENAME, dir)
     # read the single image+labelc+labelf corresponding to "index"
     image, label_c, label_f = Reader.readdata(file_path, TESTSET_SIZE, index)
+    image = permutedims(image, (2, 1, 3))
     # optionally transform the image array before returning
     bytes_to_type(T, image), label_c, label_f
 end
@@ -389,6 +386,7 @@ function testdata(::Type{T}, indices::AbstractVector; dir = nothing) where T
             labels_f[i] = yf
         end
     end
+    images = permutedims(images, (2, 1, 3, 4))
     # optionally transform the image array before returning
     bytes_to_type(T, images::Array{UInt8,4}), labels_c::Vector{Int}, labels_f::Vector{Int}
 end

--- a/src/FashionMNIST/FashionMNIST.jl
+++ b/src/FashionMNIST/FashionMNIST.jl
@@ -21,15 +21,14 @@ replacement for MNIST.
 
 - [`FashionMNIST.download`](@ref)
 
-Also, the `FashionMNIST` module is re-exporting [`convert2features`](@ref MNIST.convert2features)
-and [`convert2image`](@ref MNIST.convert2image) from the [`MNIST`](@ref) module.
+Also, the `FashionMNIST` module is re-exporting [`convert2image`](@ref MNIST.convert2image) from the [`MNIST`](@ref) module.
 """
 module FashionMNIST
     using DataDeps
     using FixedPointNumbers
     using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
     import ..MNIST
-    using ..MNIST: convert2image, convert2features
+    using ..MNIST: convert2image
     using ..MNIST.Reader
 
     export
@@ -46,7 +45,6 @@ module FashionMNIST
         testdata,
 
         convert2image,
-        convert2features,
 
         download
 

--- a/src/FashionMNIST/interface.jl
+++ b/src/FashionMNIST/interface.jl
@@ -9,52 +9,8 @@ classnames() = CLASSES
 """
     traintensor([T = N0f8], [indices]; [dir]) -> Array{T}
 
-Returns the Fashion-MNIST **training** images corresponding to
-the given `indices` as a multi-dimensional array of eltype `T`.
+Same as [`MNIST.traintensor`](@ref) but for the `FashionMNIST` dataset.
 
-The image(s) is/are returned in the native horizontal-major
-memory layout as a single numeric array. If `T <: Integer`, then
-all values will be within `0` and `255`, otherwise the values are
-scaled to be between `0` and `1`.
-
-If the parameter `indices` is omitted or an `AbstractVector`, the
-images are returned as a 3D array (i.e. a `Array{T,3}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
-image, and the third dimension denotes the index of the image.
-
-```julia-repl
-julia> FashionMNIST.traintensor() # load all training images
-28×28×60000 Array{N0f8,3}:
-[...]
-
-julia> FashionMNIST.traintensor(Float32, 1:3) # first three images as Float32
-28×28×3 Array{Float32,3}:
-[...]
-```
-
-If `indices` is an `Integer`, the single image is returned as
-`Matrix{T}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), and the second
-dimension denotes the pixel *columns* (y) of the image.
-
-```julia-repl
-julia> FashionMNIST.traintensor(1) # load first training image
-28×28 Array{N0f8,2}:
-[...]
-```
-
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
-[`convert2image`](@ref) to convert an FashionMNIST array into a
-vertical-major Julia image with the corrected color values.
-
-```julia-repl
-julia> FashionMNIST.convert2image(FashionMNIST.traintensor(1)) # convert to column-major colorant array
-28×28 Array{Gray{N0f8},2}:
-[...]
-```
 
 $(download_docstring("FashionMNIST", DEPNAME))
 """
@@ -71,51 +27,7 @@ end
 """
     testtensor([T = N0f8], [indices]; [dir]) -> Array{T}
 
-Returns the Fashion-MNIST **test** images corresponding to the
-given `indices` as a multi-dimensional array of eltype `T`.
-
-The image(s) is/are returned in the native horizontal-major
-memory layout as a single numeric array. If `T <: Integer`, then
-all values will be within `0` and `255`, otherwise the values are
-scaled to be between `0` and `1`.
-
-If the parameter `indices` is omitted or an `AbstractVector`, the
-images are returned as a 3D array (i.e. a `Array{T,3}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
-image, and the third dimension denotes the index of the image.
-
-```julia-repl
-julia> FashionMNIST.testtensor() # load all test images
-28×28×10000 Array{N0f8,3}:
-[...]
-
-julia> FashionMNIST.testtensor(Float32, 1:3) # first three images as Float32
-28×28×3 Array{Float32,3}:
-[...]
-```
-
-If `indices` is an `Integer`, the single image is returned as
-`Matrix{T}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), and the second
-dimension denotes the pixel *columns* (y) of the image.
-
-```julia-repl
-julia> FashionMNIST.testtensor(1) # load first test image
-28×28 Array{N0f8,2}:
-[...]
-```
-
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
-[`convert2image`](@ref) to convert an FashionMNIST array into a
-vertical-major Julia image with the corrected color values.
-
-```julia-repl
-julia> FashionMNIST.convert2image(FashionMNIST.testtensor(1)) # convert to column-major colorant array
-28×28 Array{Gray{N0f8},2}:
-[...]
+Same as [`MNIST.testtensor`](@ref) but for the `FashionMNIST` dataset.
 ```
 
 $(download_docstring("FashionMNIST", DEPNAME))
@@ -219,24 +131,8 @@ end
 """
     traindata([T = N0f8], [indices]; [dir]) -> images, labels
 
-Returns the Fashion-MNIST **trainingset** corresponding to the
-given `indices` as a two-element tuple. If `indices` is omitted
-the full trainingset is returned. The first element of the
-return values will be the images as a multi-dimensional array,
-and the second element the corresponding labels as integers.
+Same as [`MNIST.traindata`](@ref) but for the `FashionMNIST` dataset.
 
-The image(s) is/are returned in the native horizontal-major
-memory layout as a single numeric array of eltype `T`. If `T <:
-Integer`, then all values will be within `0` and `255`, otherwise
-the values are scaled to be between `0` and `1`. The integer
-values of the labels correspond 1-to-1 the digit that they
-represent.
-
-```julia
-train_x, train_y = FashionMNIST.traindata() # full datatset
-train_x, train_y = FashionMNIST.traindata(2) # only second observation
-train_x, train_y = FashionMNIST.traindata(dir="./FashionMNIST") # custom folder
-```
 
 $(download_docstring("FashionMNIST", DEPNAME))
 
@@ -253,24 +149,7 @@ traindata(args...; dir = nothing) = traindata(N0f8, args...; dir = dir)
 """
     testdata([T = N0f8], [indices]; [dir]) -> images, labels
 
-Returns the Fashion-MNIST **testset** corresponding to the given
-`indices` as a two-element tuple. If `indices` is omitted the
-full testset is returned. The first element of the return values
-will be the images as a multi-dimensional array, and the second
-element the corresponding labels as integers.
-
-The image(s) is/are returned in the native horizontal-major
-memory layout as a single numeric array of eltype `T`. If `T <:
-Integer`, then all values will be within `0` and `255`, otherwise
-the values are scaled to be between `0` and `1`. The integer
-values of the labels correspond 1-to-1 the digit that they
-represent.
-
-```julia
-test_x, test_y = FashionMNIST.testdata() # full datatset
-test_x, test_y = FashionMNIST.testdata(2) # only second observation
-test_x, test_y = FashionMNIST.testdata(dir="./FashionMNIST") # custom folder
-```
+Same as [`MNIST.testdata`](@ref) but for the `FashionMNIST` dataset.
 
 $(download_docstring("FashionMNIST", DEPNAME))
 

--- a/src/MNIST/MNIST.jl
+++ b/src/MNIST/MNIST.jl
@@ -20,7 +20,6 @@ the 10 possible digits (0-9).
 ## Utilities
 
 - [`MNIST.download`](@ref)
-- [`MNIST.convert2features`](@ref)
 - [`MNIST.convert2image`](@ref)
 """
 module MNIST
@@ -42,7 +41,6 @@ module MNIST
         testdata,
 
         convert2image,
-        convert2features,
 
         download
 

--- a/src/MNIST/interface.jl
+++ b/src/MNIST/interface.jl
@@ -4,15 +4,15 @@
 Returns the MNIST **training** images corresponding to the given
 `indices` as a multi-dimensional array of eltype `T`.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 3D array (i.e. a `Array{T,3}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, and the third dimension denotes the index of the image.
 
 ```julia-repl
@@ -26,9 +26,7 @@ julia> MNIST.traintensor(Float32, 1:3) # first three images as Float32
 ```
 
 If `indices` is an `Integer`, the single image is returned as
-`Matrix{T}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), and the second
-dimension denotes the pixel *columns* (y) of the image.
+`Matrix{T}`.
 
 ```julia-repl
 julia> MNIST.traintensor(1) # load first training image
@@ -36,9 +34,7 @@ julia> MNIST.traintensor(1) # load first training image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an MNIST array into a
 vertical-major Julia image with the corrected color values.
 
@@ -53,6 +49,8 @@ $(download_docstring("MNIST", DEPNAME))
 function traintensor(::Type{T}, args...; dir = nothing) where T
     path = datafile(DEPNAME, TRAINIMAGES, dir)
     images = Reader.readimages(path, args...)
+    perm = ndims(images) == 3 ? (2, 1, 3) : (2, 1)
+    images = permutedims(images, perm)
     bytes_to_type(T, images)
 end
 
@@ -66,15 +64,15 @@ end
 Returns the MNIST **test** images corresponding to the given
 `indices` as a multi-dimensional array of eltype `T`.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array. If `T <: Integer`, then
 all values will be within `0` and `255`, otherwise the values are
 scaled to be between `0` and `1`.
 
 If the parameter `indices` is omitted or an `AbstractVector`, the
 images are returned as a 3D array (i.e. a `Array{T,3}`), in which
-the first dimension corresponds to the pixel *rows* (x) of the
-image, the second dimension to the pixel *columns* (y) of the
+the first dimension corresponds to the pixel *columns* (x) of the
+image, the second dimension to the pixel *rows* (y) of the
 image, and the third dimension denotes the index of the image.
 
 ```julia-repl
@@ -88,9 +86,7 @@ julia> MNIST.testtensor(Float32, 1:3) # first three images as Float32
 ```
 
 If `indices` is an `Integer`, the single image is returned as
-`Matrix{T}` in horizontal-major layout, which means that the
-first dimension denotes the pixel *rows* (x), and the second
-dimension denotes the pixel *columns* (y) of the image.
+`Matrix{T}`.
 
 ```julia-repl
 julia> MNIST.testtensor(1) # load first test image
@@ -98,9 +94,7 @@ julia> MNIST.testtensor(1) # load first test image
 [...]
 ```
 
-As mentioned above, the images are returned in the native
-horizontal-major layout to preserve the original feature
-ordering. You can use the utility function
+You can use the utility function
 [`convert2image`](@ref) to convert an MNIST array into a
 vertical-major Julia image with the corrected color values.
 
@@ -115,6 +109,8 @@ $(download_docstring("MNIST", DEPNAME))
 function testtensor(::Type{T}, args...; dir = nothing) where T
     path = datafile(DEPNAME, TESTIMAGES, dir)
     images = Reader.readimages(path, args...)
+    perm = ndims(images) == 3 ? (2, 1, 3) : (2, 1)
+    images = permutedims(images, perm)
     bytes_to_type(T, images)
 end
 
@@ -209,7 +205,7 @@ full trainingset is returned. The first element of three return
 values will be the images as a multi-dimensional array, and the
 second element the corresponding labels as integers.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer
@@ -243,7 +239,7 @@ full testset is returned. The first element of three return
 values will be the images as a multi-dimensional array, and the
 second element the corresponding labels as integers.
 
-The image(s) is/are returned in the native horizontal-major
+The image(s) is/are returned in the vertical-major
 memory layout as a single numeric array of eltype `T`. If `T <:
 Integer`, then all values will be within `0` and `255`, otherwise
 the values are scaled to be between `0` and `1`. The integer

--- a/src/MNIST/utils.jl
+++ b/src/MNIST/utils.jl
@@ -1,29 +1,4 @@
 """
-    convert2features(array)
-
-Convert the given MNIST tensor to a feature matrix (or feature
-vector in the case of a single image). The purpose of this
-function is to drop the spatial dimensions such that traditional
-ML algorithms can process the dataset.
-
-```julia
-julia> MNIST.convert2features(MNIST.traintensor()) # full training data
-784×60000 Array{N0f8,2}:
-[...]
-
-julia> MNIST.convert2features(MNIST.traintensor(1)) # first observation
-784-element Array{N0f8,1}:
-[...]
-```
-"""
-convert2features(array::AbstractMatrix{<:Number}) = vec(array)
-
-function convert2features(array::AbstractArray{<:Number,3})
-    nrows, ncols, nimages = size(array)
-    reshape(array, (nrows * ncols, nimages))
-end
-
-"""
     convert2image(array) -> Array{Gray}
 
 Convert the given MNIST horizontal-major tensor (or feature matrix)
@@ -41,38 +16,16 @@ julia> MNIST.convert2image(MNIST.traintensor(1)) # first training image
 [...]
 ```
 """
-function convert2image(array::AbstractVector{<:Number})
-    @assert length(array) % 784 == 0
-    if length(array) == 784
-        convert2image(reshape(array, 28, 28))
+function convert2image(array::AbstractArray{T}) where {T<:Number}
+    nlast = size(array)[end] 
+    array = reshape(array, 28, 28, :)
+    if size(array)[end] == 1 && nlast != 1
+        array = dropdims(array, dims=3)
+    end    
+    if any(x -> x > 1, array) # simple check if x in [0,1]
+        img = _colorview(Gray, array ./ T(255))
     else
-        n = Int(length(array) / 784)
-        convert2image(reshape(array, 28, 28, n))
+        img = _colorview(Gray, array)
     end
-end
-
-function convert2image(array::AbstractMatrix{T}) where {T<:Number}
-    if size(array) == (28, 28)
-        # simple check to see if values are normalized to [0,1]
-        if any(x->x > 50, array)
-            _colorview(Gray, T(1) .- transpose(array) ./ T(255))
-        else
-            _colorview(Gray, T(1) .- transpose(array))
-        end
-    else # feature matrix
-        @assert size(array, 1) == 784
-        n = size(array, 2)
-        convert2image(reshape(array, 28, 28, n))
-    end
-end
-
-function convert2image(array::AbstractArray{T,3}) where {T<:Number}
-    h, w, n = size(array)
-    @assert h == 28 && w == 28
-    # simple check to see if values are normalized to [0,1]
-    if any(x->x > 50, array)
-        _colorview(Gray, permutedims(T(1) .- array ./ T(255), [2,1,3]))
-    else
-        _colorview(Gray, permutedims(T(1) .- array, [2,1,3]))
-    end
+    img
 end

--- a/src/SVHN2/SVHN2.jl
+++ b/src/SVHN2/SVHN2.jl
@@ -25,7 +25,6 @@ additional to use as extra training data.
 
 - [`SVHN2.download`](@ref)
 - [`SVHN2.classnames`](@ref)
-- [`SVHN2.convert2features`](@ref)
 - [`SVHN2.convert2image`](@ref)
 """
 module SVHN2
@@ -50,7 +49,6 @@ module SVHN2
         extradata,
 
         convert2image,
-        convert2features,
 
         download
 

--- a/src/SVHN2/utils.jl
+++ b/src/SVHN2/utils.jl
@@ -1,40 +1,4 @@
 """
-    convert2features(array)
-
-Convert the given SVHN tensor to a feature matrix (or feature
-vector in the case of a single image). The purpose of this
-function is to drop the spatial dimensions such that traditional
-ML algorithms can process the dataset.
-
-```julia
-julia> SVHN2.convert2features(SVHN2.traindata(Float32)[1]) # full training data
-3072×50000 Array{Float32,2}:
-[...]
-
-julia> SVHN2.convert2features(SVHN2.traindata(Float32,1)[1]) # first observation
-3072-element Array{Float32,1}:
-[...]
-```
-"""
-function convert2features(array::AbstractArray{<:Number,3})
-    nrows, ncols, nchan = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    vec(array)
-end
-
-function convert2features(array::AbstractArray{<:Number,4})
-    nrows, ncols, nchan, nimages = size(array)
-    @assert nchan == 3 "the given array should have the RGB channel in the third dimension"
-    reshape(array, (nrows * ncols * nchan, nimages))
-end
-
-convert2features(array::AbstractArray{<:RGB,2}) =
-    convert2features(permutedims(_channelview(array), (2,3,1)))
-
-convert2features(array::AbstractArray{<:RGB,3}) =
-    convert2features(permutedims(_channelview(array), (2,3,1,4)))
-
-"""
     convert2image(array) -> Array{RGB}
 
 Convert the given SVHN tensor (or feature vector/matrix) to a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using MLDatasets
+using ImageCore
 
 tests = [
     "tst_iris.jl",

--- a/test/tst_cifar10.jl
+++ b/test/tst_cifar10.jl
@@ -6,6 +6,16 @@ using FixedPointNumbers
 using MLDatasets
 using DataDeps
 
+function readimage(path, i)
+    x = CIFAR10.Reader.readdata(path, i)[1]
+    if ndims(x) == 4
+        permutedims(x, (2, 1, 3, 4))
+    else
+        permutedims(x, (2, 1, 3,))
+    end
+end
+
+
 @testset "Constants" begin
     @test CIFAR10.Reader.NROW === 32
     @test CIFAR10.Reader.NCOL === 32
@@ -21,37 +31,25 @@ using DataDeps
     @test DataDeps.registry["CIFAR10"] isa DataDeps.DataDep
 end
 
-@testset "convert2features" begin
-    data = rand(32,32,3)
-    ref = vec(data)
-    @test @inferred(CIFAR10.convert2features(data)) == ref
-    @test @inferred(CIFAR10.convert2features(CIFAR10.convert2image(data))) == ref
-
-    data = rand(32,32,3,2)
-    ref = reshape(data, (32*32*3, 2))
-    @test @inferred(CIFAR10.convert2features(data)) == ref
-    @test @inferred(CIFAR10.convert2features(CIFAR10.convert2image(data))) == ref
-end
 
 @testset "convert2images" begin
-    @test_throws AssertionError CIFAR10.convert2image(rand(100))
-    @test_throws AssertionError CIFAR10.convert2image(rand(228,1))
-    @test_throws AssertionError CIFAR10.convert2image(rand(32,32,4))
+    @test_throws DimensionMismatch CIFAR10.convert2image(rand(100))
+    @test_throws DimensionMismatch CIFAR10.convert2image(rand(228,1))
+    @test_throws DimensionMismatch CIFAR10.convert2image(rand(32,32,4))
 
     data = rand(N0f8,32,32,3)
-    A = @inferred CIFAR10.convert2image(data)
+    A = CIFAR10.convert2image(data)
     @test size(A) == (32,32)
     @test eltype(A) == RGB{N0f8}
     @test CIFAR10.convert2image(vec(data)) == A
-    @test permutedims(channelview(A), (3,2,1)) == data
+    @test permutedims(channelview(A), (2,3,1)) == data
     @test CIFAR10.convert2image(reinterpret(UInt8, data)) == A
 
     data = rand(N0f8,32,32,3,2)
-    A = @inferred CIFAR10.convert2image(data)
+    A = CIFAR10.convert2image(data)
     @test size(A) == (32,32,2)
     @test eltype(A) == RGB{N0f8}
     @test CIFAR10.convert2image(vec(data)) == A
-    @test CIFAR10.convert2image(CIFAR10.convert2features(data)) == A
     @test CIFAR10.convert2image(reinterpret(UInt8, data)) == A
 end
 
@@ -72,50 +70,39 @@ else
 
         @testset "Test that traintensor are the train images" begin
             path = joinpath(data_dir, "cifar-10-batches-bin", "data_batch_1.bin")
-            @test CIFAR10.traintensor(1) == reinterpret(N0f8, CIFAR10.Reader.readdata(path, 1)[1])
-            @test CIFAR10.traintensor(Float64, 1) ≈ CIFAR10.Reader.readdata(path, 1)[1] ./ 255
-            @test CIFAR10.traintensor(Int, 1) == Int.(CIFAR10.Reader.readdata(path, 1)[1])
-            @test CIFAR10.traintensor(UInt8, 1) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.traintensor(UInt8, 2) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.traintensor(UInt8, 10_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.traintensor(1) == reinterpret(N0f8, readimage(path, 1))
+            @test CIFAR10.traintensor(Float64, 1) ≈ readimage(path, 1) ./ 255
+            @test CIFAR10.traintensor(Int, 1) == Int.(readimage(path, 1))
+            @test CIFAR10.traintensor(UInt8, 1) == readimage(path, 1)
+            @test CIFAR10.traintensor(UInt8, 2) == readimage(path, 2)
+            @test CIFAR10.traintensor(UInt8, 10_000) == readimage(path, 10_000)
             path = joinpath(data_dir, "cifar-10-batches-bin", "data_batch_2.bin")
-            @test CIFAR10.traintensor(UInt8, 10_001) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.traintensor(UInt8, 10_002) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.traintensor(UInt8, 20_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.traintensor(UInt8, 10_001) == readimage(path, 1)
+            @test CIFAR10.traintensor(UInt8, 10_002) == readimage(path, 2)
+            @test CIFAR10.traintensor(UInt8, 20_000) == readimage(path, 10_000)
             path = joinpath(data_dir, "cifar-10-batches-bin", "data_batch_3.bin")
-            @test CIFAR10.traintensor(UInt8, 20_001) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.traintensor(UInt8, 20_002) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.traintensor(UInt8, 30_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.traintensor(UInt8, 20_001) == readimage(path, 1)
+            @test CIFAR10.traintensor(UInt8, 20_002) == readimage(path, 2)
+            @test CIFAR10.traintensor(UInt8, 30_000) == readimage(path, 10_000)
             path = joinpath(data_dir, "cifar-10-batches-bin", "data_batch_4.bin")
-            @test CIFAR10.traintensor(UInt8, 30_001) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.traintensor(UInt8, 30_002) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.traintensor(UInt8, 40_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.traintensor(UInt8, 30_001) == readimage(path, 1)
+            @test CIFAR10.traintensor(UInt8, 30_002) == readimage(path, 2)
+            @test CIFAR10.traintensor(UInt8, 40_000) == readimage(path, 10_000)
             path = joinpath(data_dir, "cifar-10-batches-bin", "data_batch_5.bin")
-            @test CIFAR10.traintensor(UInt8, 40_001) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.traintensor(UInt8, 40_002) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.traintensor(UInt8, 50_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.traintensor(UInt8, 40_001) == readimage(path, 1)
+            @test CIFAR10.traintensor(UInt8, 40_002) == readimage(path, 2)
+            @test CIFAR10.traintensor(UInt8, 50_000) == readimage(path, 10_000)
         end
 
         @testset "Test that testtensor are the test images" begin
             path = joinpath(data_dir, "cifar-10-batches-bin", "test_batch.bin")
-            @test CIFAR10.testtensor(1) == reinterpret(N0f8, CIFAR10.Reader.readdata(path, 1)[1])
-            @test CIFAR10.testtensor(Float64, 1) ≈ CIFAR10.Reader.readdata(path, 1)[1] ./ 255
-            @test CIFAR10.testtensor(Int, 1) == Int.(CIFAR10.Reader.readdata(path, 1)[1])
-            @test CIFAR10.testtensor(UInt8, 1) == CIFAR10.Reader.readdata(path, 1)[1]
-            @test CIFAR10.testtensor(UInt8, 2) == CIFAR10.Reader.readdata(path, 2)[1]
-            @test CIFAR10.testtensor(UInt8, 10_000) == CIFAR10.Reader.readdata(path, 10_000)[1]
+            @test CIFAR10.testtensor(1) == reinterpret(N0f8, readimage(path, 1))
+            @test CIFAR10.testtensor(Float64, 1) ≈ readimage(path, 1) ./ 255
+            @test CIFAR10.testtensor(Int, 1) == Int.(readimage(path, 1))
+            @test CIFAR10.testtensor(UInt8, 1) == readimage(path, 1)
+            @test CIFAR10.testtensor(UInt8, 2) == readimage(path, 2)
+            @test CIFAR10.testtensor(UInt8, 10_000) == readimage(path, 10_000)
         end
-
-        @test CIFAR10.traintensor(UInt8, 1)[11:13, 12:14, 1] == [
-            0x6f  0x8a  0xa5;
-            0x92  0xd5  0xe5;
-            0x88  0xb2  0xb7;
-        ]
-        @test CIFAR10.testtensor(UInt8, 1)[11:13, 12:14, 1] == [
-            0xc7  0xa8  0x91;
-            0xaa  0x89  0xa7;
-            0xb9  0xba  0xbd;
-        ]
 
         # These tests check if the functions return internaly
         # consistent results for different parameters (e.g. index

--- a/test/tst_cifar100.jl
+++ b/test/tst_cifar100.jl
@@ -6,6 +6,16 @@ using FixedPointNumbers
 using MLDatasets
 using DataDeps
 
+
+function readimage(path, m, i)
+    x = CIFAR100.Reader.readdata(path, m, i)[1]
+    if ndims(x) == 4
+        permutedims(x, (2, 1, 3, 4))
+    else
+        permutedims(x, (2, 1, 3,))
+    end
+end
+
 @testset "Constants" begin
     @test CIFAR100.Reader.NROW === 32
     @test CIFAR100.Reader.NCOL === 32
@@ -18,9 +28,6 @@ using DataDeps
     @test DataDeps.registry["CIFAR100"] isa DataDeps.DataDep
 end
 
-@testset "convert2features" begin
-    @test CIFAR100.convert2features === CIFAR10.convert2features
-end
 
 @testset "convert2images" begin
     @test CIFAR100.convert2image === CIFAR10.convert2image
@@ -32,7 +39,7 @@ if parse(Bool, get(ENV, "CI", "false"))
     @info "CI detected: skipping dataset download"
 else
     data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
-        datadep"Iris"
+        datadep"CIFAR100"
     end
 
     @testset "classnames" begin
@@ -52,34 +59,23 @@ else
 
         @testset "Test that traintensor are the train images" begin
             path = joinpath(data_dir, "cifar-100-binary", "train.bin")
-            @test CIFAR100.traintensor(1) == reinterpret(N0f8, CIFAR100.Reader.readdata(path, 10_000, 1)[1])
-            @test CIFAR100.traintensor(Float64, 1) ≈ CIFAR100.Reader.readdata(path, 10_000, 1)[1] ./ 255
-            @test CIFAR100.traintensor(Int, 1) == Int.(CIFAR100.Reader.readdata(path, 10_000, 1)[1])
-            @test CIFAR100.traintensor(UInt8, 1) == CIFAR100.Reader.readdata(path, 10_000, 1)[1]
-            @test CIFAR100.traintensor(UInt8, 2) == CIFAR100.Reader.readdata(path, 10_000, 2)[1]
-            @test CIFAR100.traintensor(UInt8, 10_000) == CIFAR100.Reader.readdata(path, 10_000, 10_000)[1]
+            @test CIFAR100.traintensor(1) == reinterpret(N0f8, readimage(path, 10_000, 1))
+            @test CIFAR100.traintensor(Float64, 1) ≈ readimage(path, 10_000, 1) ./ 255
+            @test CIFAR100.traintensor(Int, 1) == Int.(readimage(path, 10_000, 1))
+            @test CIFAR100.traintensor(UInt8, 1) == readimage(path, 10_000, 1)
+            @test CIFAR100.traintensor(UInt8, 2) == readimage(path, 10_000, 2)
+            @test CIFAR100.traintensor(UInt8, 10_000) == readimage(path, 10_000, 10_000)
         end
 
         @testset "Test that testtensor are the test images" begin
             path = joinpath(data_dir, "cifar-100-binary", "test.bin")
-            @test CIFAR100.testtensor(1) == reinterpret(N0f8, CIFAR100.Reader.readdata(path, 10_000, 1)[1])
-            @test CIFAR100.testtensor(Float64, 1) ≈ CIFAR100.Reader.readdata(path, 10_000, 1)[1] ./ 255
-            @test CIFAR100.testtensor(Int, 1) == Int.(CIFAR100.Reader.readdata(path, 10_000, 1)[1])
-            @test CIFAR100.testtensor(UInt8, 1) == CIFAR100.Reader.readdata(path, 10_000, 1)[1]
-            @test CIFAR100.testtensor(UInt8, 2) == CIFAR100.Reader.readdata(path, 10_000, 2)[1]
-            @test CIFAR100.testtensor(UInt8, 10_000) == CIFAR100.Reader.readdata(path, 10_000, 10_000)[1]
+            @test CIFAR100.testtensor(1) == reinterpret(N0f8, readimage(path, 10_000, 1))
+            @test CIFAR100.testtensor(Float64, 1) ≈ readimage(path, 10_000, 1) ./ 255
+            @test CIFAR100.testtensor(Int, 1) == Int.(readimage(path, 10_000, 1))
+            @test CIFAR100.testtensor(UInt8, 1) == readimage(path, 10_000, 1)
+            @test CIFAR100.testtensor(UInt8, 2) == readimage(path, 10_000, 2)
+            @test CIFAR100.testtensor(UInt8, 10_000) == readimage(path, 10_000, 10_000)
         end
-
-        @test CIFAR100.traintensor(UInt8, 1)[11:13, 12:14, 1] == [
-            0x5b  0x49  0x49;
-            0x45  0x2a  0x6a;
-            0x93  0x9b  0xb1;
-        ]
-        @test CIFAR100.testtensor(UInt8, 1)[11:13, 12:14, 1] == [
-            0xef  0xe7  0xe5;
-            0xf1  0xe6  0xe0;
-            0xf3  0xe5  0xd6;
-        ]
 
         # These tests check if the functions return internaly
         # consistent results for different parameters (e.g. index

--- a/test/tst_fashion_mnist.jl
+++ b/test/tst_fashion_mnist.jl
@@ -17,9 +17,6 @@ using DataDeps
     @test DataDeps.registry["FashionMNIST"] isa DataDeps.DataDep
 end
 
-@testset "convert2features" begin
-    @test FashionMNIST.convert2features === MNIST.convert2features
-end
 
 @testset "convert2images" begin
     @test FashionMNIST.convert2image === MNIST.convert2image

--- a/test/tst_mnist.jl
+++ b/test/tst_mnist.jl
@@ -5,6 +5,16 @@ using FixedPointNumbers
 using MLDatasets
 using DataDeps
 
+function _readimages(IMAGES, i)
+    img = MNIST.Reader.readimages(IMAGES, i) 
+    # convert to vertical major
+    if ndims(img) == 3
+        permutedims(img, (2, 1, 3))
+    else
+        permutedims(img, (2, 1))
+    end
+end
+
 @testset "Constants" begin
     @test MNIST.Reader.IMAGEOFFSET == 16
     @test MNIST.Reader.LABELOFFSET == 8
@@ -17,23 +27,15 @@ using DataDeps
     @test DataDeps.registry["MNIST"] isa DataDeps.DataDep
 end
 
-@testset "convert2features" begin
-    data = rand(28,28)
-    @test @inferred(MNIST.convert2features(data)) == vec(data)
-
-    data = rand(28,28,2)
-    @test @inferred(MNIST.convert2features(data)) == reshape(data, (28*28, 2))
-end
-
 @testset "convert2images" begin
-    @test_throws AssertionError MNIST.convert2image(rand(100))
-    @test_throws AssertionError MNIST.convert2image(rand(27,28,1))
-    @test_throws AssertionError MNIST.convert2image(rand(228,1))
+    @test_throws DimensionMismatch MNIST.convert2image(rand(100))
+    @test_throws DimensionMismatch MNIST.convert2image(rand(27,28,1))
+    @test_throws DimensionMismatch MNIST.convert2image(rand(228,1))
 
     data = rand(N0f8,28,28)
     data[1] = 0 # make sure 0 means "white"
     A = MNIST.convert2image(data)
-    @test A[1] == 1.0
+    @test A[1] == 0
     @test size(A) == (28,28)
     @test eltype(A) == Gray{N0f8}
     @test MNIST.convert2image(vec(data)) == A
@@ -41,11 +43,10 @@ end
     data = rand(N0f8,28,28,2)
     data[1] = 0
     A = MNIST.convert2image(data)
-    @test A[1] == 1.0
+    @test A[1] == 0
     @test size(A) == (28,28,2)
     @test eltype(A) == Gray{N0f8}
     @test MNIST.convert2image(vec(data)) == A
-    @test MNIST.convert2image(MNIST.convert2features(data)) == A
 end
 
 # NOT executed on CI. only executed locally.
@@ -77,29 +78,18 @@ else
 
         @testset "Test that traintensor are the train images" begin
             for i = rand(1:60_000, 10)
-                @test MNIST.traintensor(i) == reinterpret(N0f8, MNIST.Reader.readimages(_TRAINIMAGES, i))
-                @test MNIST.traintensor(Float64, i) == MNIST.Reader.readimages(_TRAINIMAGES, i) ./ 255.0
-                @test MNIST.traintensor(UInt8, i) == MNIST.Reader.readimages(_TRAINIMAGES, i)
+                @test MNIST.traintensor(i) == reinterpret(N0f8, _readimages(_TRAINIMAGES, i))
+                @test MNIST.traintensor(Float64, i) == _readimages(_TRAINIMAGES, i) ./ 255.0
+                @test MNIST.traintensor(UInt8, i) == _readimages(_TRAINIMAGES, i)
             end
         end
         @testset "Test that testtensor are the test images" begin
             for i = rand(1:10_000, 10)
-                @test MNIST.testtensor(i) == reinterpret(N0f8, MNIST.Reader.readimages(_TESTIMAGES, i))
-                @test MNIST.testtensor(Float64, i) == MNIST.Reader.readimages(_TESTIMAGES, i) ./ 255.0
-                @test MNIST.testtensor(UInt8, i) == MNIST.Reader.readimages(_TESTIMAGES, i)
+                @test MNIST.testtensor(i) == reinterpret(N0f8, _readimages(_TESTIMAGES, i))
+                @test MNIST.testtensor(Float64, i) == _readimages(_TESTIMAGES, i) ./ 255.0
+                @test MNIST.testtensor(UInt8, i) == _readimages(_TESTIMAGES, i)
             end
         end
-
-        # Test that `readtrainimage` is the horizontal-major layout
-        # by comparing to a hand checked result
-        @test MNIST.Reader.readimages(_TRAINIMAGES, 1)[11:13,12:14] ==
-                [0x00 0x00 0x00;
-                0x8b 0x0b 0x00;
-                0xfd 0xbe 0x23]
-        @test MNIST.traintensor(UInt8, 1)[11:13,12:14] ==
-                [0x00 0x00 0x00;
-                0x8b 0x0b 0x00;
-                0xfd 0xbe 0x23]
 
         # These tests check if the functions return internaly
         # consistent results for different parameters (e.g. index

--- a/test/tst_svhn2.jl
+++ b/test/tst_svhn2.jl
@@ -16,18 +16,6 @@ using MAT
     @test DataDeps.registry["SVHN2"] isa DataDeps.DataDep
 end
 
-@testset "convert2features" begin
-    data = rand(32,32,3)
-    ref = vec(data)
-    @test @inferred(SVHN2.convert2features(data)) == ref
-    @test @inferred(SVHN2.convert2features(SVHN2.convert2image(data))) == ref
-
-    data = rand(32,32,3,2)
-    ref = reshape(data, (32*32*3, 2))
-    @test @inferred(SVHN2.convert2features(data)) == ref
-    @test @inferred(SVHN2.convert2features(SVHN2.convert2image(data))) == ref
-end
-
 @testset "convert2images" begin
     @test_throws AssertionError SVHN2.convert2image(rand(100))
     @test_throws AssertionError SVHN2.convert2image(rand(228,1))
@@ -46,7 +34,6 @@ end
     @test size(A) == (32,32,2)
     @test eltype(A) == RGB{N0f8}
     @test SVHN2.convert2image(vec(data)) == A
-    @test SVHN2.convert2image(SVHN2.convert2features(data)) == A
     @test SVHN2.convert2image(reinterpret(UInt8, data)) == A
 end
 


### PR DESCRIPTION
Most downstream packages such as Flux, Knet, and the Images ecosystem, assume the image tensors to be in WH format for greyscale and in WHC format for rgb. 
Our SVHN2 dataset is consistent with julia ecosystem, while MNIST, FashionMNIST, CIFAR10 and CIFAR100 return images HW format. This is annoying at the very least, but most importantly it is the potential source of very hard to detect bugs. 

Therefore this PR does the following:
- makes every vision dataset return tensors in WH format
- Since this is breaking, I'm also bumping version number.  
- I'm removing the `convert2features` since it's just a reshape into a vector (or a matrix for a batch of images) 