### PR TITLE
Include EMNIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,23 @@ Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels`
 
 (*) Note that the SVHN-2 dataset provides an additional 531131 observations aside from the training- and testset
 
-[**EMNIST**](https://www.nist.gov/itl/products-and-services/emnist-dataset) packages 6 different extensions of the MNIST dataset involving letters and digits and variety of test train split options. 
+[**EMNIST**](https://www.nist.gov/itl/products-and-services/emnist-dataset) packages 6 different extensions of the MNIST dataset involving letters and digits and variety of test train split options. Each extension has the standard test/train data/labels nested under it as shown below.
 
+```julia
+traindata = EMNIST.Balanced.traindata()
+testdata = EMNIST.Balanced.testdata()
+trainlabels = EMNIST.Balanced.trainlabels()
+testlabels = EMNIST.Balanced.testlabels()
+```
+
+Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels` | `balanced classes`
+:------:|:-------:|:-------------:|:-------------:|:------------:|:------------:|:------------:
+**ByClass** | 62 | 697932x28x28 | 697932x1 | 116323x28x28 | 116323x1 | no
+**ByMerge** | 47 | 697932x28x28 | 697932x1 | 116323x28x28 | 116323x1 | no
+**Balanced** | 47 | 112800x28x28 | 112800x1 | 18800x28x28 | 18800x1 | yes
+**Letters** | 26 | 124800x28x28 | 124800x1 | 20800x28x28 | 208000x1 | yes
+**Digits** | 10 | 240000x28x28 | 240000x1 | 40000x28x28 | 40000x1 | yes
+**MNIST** | 10 | 60000x28x28 | 60000x1 | 10000x28x28 | 10000x1 | yes
 
 ### Misc. Datasets
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels`
 
 (*) Note that the SVHN-2 dataset provides an additional 531131 observations aside from the training- and testset
 
+[**EMNIST**](https://www.nist.gov/itl/products-and-services/emnist-dataset) packages 6 different extensions of the MNIST dataset involving letters and digits and variety of test train split options. 
+
 
 ### Misc. Datasets
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ trainlabels = EMNIST.Balanced.trainlabels()
 testlabels = EMNIST.Balanced.testlabels()
 ```
 
-Dataset | Classes | `traintensor` | `trainlabels` | `testtensor` | `testlabels` | `balanced classes`
+Dataset | Classes | `traindata` | `trainlabels` | `testdata` | `testlabels` | `balanced classes`
 :------:|:-------:|:-------------:|:-------------:|:------------:|:------------:|:------------:
 **ByClass** | 62 | 697932x28x28 | 697932x1 | 116323x28x28 | 116323x1 | no
 **ByMerge** | 47 | 697932x28x28 | 697932x1 | 116323x28x28 | 116323x1 | no

--- a/src/EMNIST/EMNIST.jl
+++ b/src/EMNIST/EMNIST.jl
@@ -1,0 +1,276 @@
+export EMNIST
+module EMNIST
+    using DataDeps
+    using BinDeps
+    using FixedPointNumbers
+    using MAT: matopen, matread
+    using ..MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+    using ..MNIST: convert2image
+
+        const DEPNAME = "EMNIST"
+
+        """
+            download([dir]; [i_accept_the_terms_of_use])
+
+        Trigger the (interactive) download of the full dataset into
+        "`dir`". If no `dir` is provided the dataset will be
+        downloaded into "~/.julia/datadeps/$DEPNAME".
+
+        This function will display an interactive dialog unless
+        either the keyword parameter `i_accept_the_terms_of_use` or
+        the environment variable `DATADEPS_ALWAY_ACCEPT` is set to
+        `true`. Note that using the data responsibly and respecting
+        copyright/terms-of-use remains your responsibility.
+        """
+        download(args...; kw...) = download_dep(DEPNAME, args...; kw...)
+
+        function __init__()
+            register(DataDep(
+                DEPNAME,
+                """
+                Dataset: The EMNIST Dataset
+                Authors: Gregory Cohen, Saeed Afshar, Jonathan Tapson, and Andre van Schaik
+                Website: https://www.nist.gov/itl/products-and-services/emnist-dataset
+
+                [Cohen et al., 2017]
+                    Cohen, G., Afshar, S., Tapson, J., & van Schaik, A. (2017).
+                    EMNIST: an extension of MNIST to handwritten letters.
+                    Retrieved from http://arxiv.org/abs/1702.05373
+
+                The EMNIST dataset is a set of handwritten character digits derived from the
+                NIST Special Database 19 (https://www.nist.gov/srd/nist-special-database-19)
+                and converted to a 28x28 pixel image format and dataset structure that directly
+                matches the MNIST dataset (http://yann.lecun.com/exdb/mnist/). Further information
+                on the dataset contents and conversion process can be found in the paper available
+                at https://arxiv.org/abs/1702.05373v1.
+
+                The files are available for download at the official
+                website linked above. Note that using the data
+                responsibly and respecting copyright remains your
+                responsibility. For example the website mentions that
+                the data is for non-commercial use only. Please read
+                the website to make sure you want to download the
+                dataset.
+                """,
+                "http://www.itl.nist.gov/iaui/vip/cs_links/EMNIST/matlab.zip",
+                "e1fa805cdeae699a52da0b77c2db17f6feb77eed125f9b45c022e7990444df95",
+                post_fetch_method = file -> (run(BinDeps.unpack_cmd(file,dirname(file),".zip","")); rm(file))
+            ))
+        end
+
+        module balanced
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-balanced.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+
+        module byclass
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-byclass.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+
+        module bymerge
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-bymerge.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+
+        module digits
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-digits.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+
+        module letters
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-letters.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+
+        module mnist
+            using DataDeps
+            using BinDeps
+            using FixedPointNumbers
+            using MAT: matopen, matread
+            using ...MLDatasets: bytes_to_type, datafile, download_dep, download_docstring
+            using ...MNIST: convert2image
+
+            const DEPNAME = "EMNIST"
+            const FILENAME = "matlab/emnist-mnist.mat"
+
+            function traindata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["train"]["images"],:,28,28)
+            end
+
+            function testdata(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return reshape(vars["dataset"]["test"]["images"],:,28,28)
+            end
+
+            function trainlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["train"]["labels"]
+            end
+
+            function testlabels(; dir = nothing)
+                path = datafile(DEPNAME, FILENAME, dir)
+                vars = matread(path)
+                return vars["dataset"]["test"]["labels"]
+            end
+        end
+end

--- a/src/EMNIST/EMNIST.jl
+++ b/src/EMNIST/EMNIST.jl
@@ -58,7 +58,7 @@ module EMNIST
             ))
         end
 
-        module balanced
+        module Balanced
             using DataDeps
             using BinDeps
             using FixedPointNumbers
@@ -94,7 +94,7 @@ module EMNIST
             end
         end
 
-        module byclass
+        module ByClass
             using DataDeps
             using BinDeps
             using FixedPointNumbers
@@ -130,7 +130,7 @@ module EMNIST
             end
         end
 
-        module bymerge
+        module ByMerge
             using DataDeps
             using BinDeps
             using FixedPointNumbers
@@ -166,7 +166,7 @@ module EMNIST
             end
         end
 
-        module digits
+        module Digits
             using DataDeps
             using BinDeps
             using FixedPointNumbers
@@ -202,7 +202,7 @@ module EMNIST
             end
         end
 
-        module letters
+        module Letters
             using DataDeps
             using BinDeps
             using FixedPointNumbers
@@ -238,7 +238,7 @@ module EMNIST
             end
         end
 
-        module mnist
+        module MNIST
             using DataDeps
             using BinDeps
             using FixedPointNumbers

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -35,6 +35,7 @@ include("FashionMNIST/FashionMNIST.jl")
 include("SVHN2/SVHN2.jl")
 include("PTBLM/PTBLM.jl")
 include("UD_English/UD_English.jl")
+include("EMNIST/EMNIST.jl")
 
 function __init__()
     # initialize optional dependencies

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ tests = [
     "tst_mnist.jl",
     "tst_fashion_mnist.jl",
     "tst_svhn2.jl",
+    "tst_emnist.jl",
 ]
 
 for t in tests

--- a/test/tst_emnist.jl
+++ b/test/tst_emnist.jl
@@ -1,0 +1,94 @@
+module EMNIST_Tests
+    using Test
+    using DataDeps
+    using MLDatasets
+
+    if parse(Bool, get(ENV, "CI", "false"))
+        @info "CI detected: skipping dataset download"
+    else
+        data_dir = withenv("DATADEPS_ALWAY_ACCEPT"=>"true") do
+            datadep"EMNIST"
+        end
+
+        @testset "EMNIST" begin
+            X_train = EMNIST.balanced.traindata()
+            X_test = EMNIST.balanced.testdata()
+            Y_train = EMNIST.balanced.trainlabels()
+            Y_test = EMNIST.balanced.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (112800, 28, 28)
+            @test size(X_test) == (18800, 28, 28)
+            @test size(Y_train) == (112800, 1)
+            @test size(Y_test) == (18800, 1)
+
+            X_train = EMNIST.byclass.traindata()
+            X_test = EMNIST.byclass.testdata()
+            Y_train = EMNIST.byclass.trainlabels()
+            Y_test = EMNIST.byclass.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (697932, 28, 28)
+            @test size(X_test) == (116323, 28, 28)
+            @test size(Y_train) == (697932, 1)
+            @test size(Y_test) == (116323, 1)
+
+            X_train = EMNIST.bymerge.traindata()
+            X_test = EMNIST.bymerge.testdata()
+            Y_train = EMNIST.bymerge.trainlabels()
+            Y_test = EMNIST.bymerge.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (697932, 28, 28)
+            @test size(X_test) == (116323, 28, 28)
+            @test size(Y_train) == (697932, 1)
+            @test size(Y_test) == (116323, 1)
+
+            X_train = EMNIST.digits.traindata()
+            X_test = EMNIST.digits.testdata()
+            Y_train = EMNIST.digits.trainlabels()
+            Y_test = EMNIST.digits.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (240000, 28, 28)
+            @test size(X_test) == (40000, 28, 28)
+            @test size(Y_train) == (240000, 1)
+            @test size(Y_test) == (40000, 1)
+
+            X_train = EMNIST.letters.traindata()
+            X_test = EMNIST.letters.testdata()
+            Y_train = EMNIST.letters.trainlabels()
+            Y_test = EMNIST.letters.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (124800, 28, 28)
+            @test size(X_test) == (20800, 28, 28)
+            @test size(Y_train) == (124800, 1)
+            @test size(Y_test) == (20800, 1)
+
+            X_train = EMNIST.mnist.traindata()
+            X_test = EMNIST.mnist.testdata()
+            Y_train = EMNIST.mnist.trainlabels()
+            Y_test = EMNIST.mnist.testlabels()
+            @test X_train isa Array{UInt8,3}
+            @test X_test isa Array{UInt8,3}
+            @test Y_train isa Array{Float64,2}
+            @test Y_test isa Array{Float64,2}
+            @test size(X_train) == (60000, 28, 28)
+            @test size(X_test) == (10000, 28, 28)
+            @test size(Y_train) == (60000, 1)
+            @test size(Y_test) == (10000, 1)
+        end
+    end
+
+end

--- a/test/tst_emnist.jl
+++ b/test/tst_emnist.jl
@@ -11,10 +11,10 @@ module EMNIST_Tests
         end
 
         @testset "EMNIST" begin
-            X_train = EMNIST.balanced.traindata()
-            X_test = EMNIST.balanced.testdata()
-            Y_train = EMNIST.balanced.trainlabels()
-            Y_test = EMNIST.balanced.testlabels()
+            X_train = EMNIST.Balanced.traindata()
+            X_test = EMNIST.Balanced.testdata()
+            Y_train = EMNIST.Balanced.trainlabels()
+            Y_test = EMNIST.Balanced.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}
@@ -24,10 +24,10 @@ module EMNIST_Tests
             @test size(Y_train) == (112800, 1)
             @test size(Y_test) == (18800, 1)
 
-            X_train = EMNIST.byclass.traindata()
-            X_test = EMNIST.byclass.testdata()
-            Y_train = EMNIST.byclass.trainlabels()
-            Y_test = EMNIST.byclass.testlabels()
+            X_train = EMNIST.ByClass.traindata()
+            X_test = EMNIST.ByClass.testdata()
+            Y_train = EMNIST.ByClass.trainlabels()
+            Y_test = EMNIST.ByClass.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}
@@ -37,10 +37,10 @@ module EMNIST_Tests
             @test size(Y_train) == (697932, 1)
             @test size(Y_test) == (116323, 1)
 
-            X_train = EMNIST.bymerge.traindata()
-            X_test = EMNIST.bymerge.testdata()
-            Y_train = EMNIST.bymerge.trainlabels()
-            Y_test = EMNIST.bymerge.testlabels()
+            X_train = EMNIST.ByMerge.traindata()
+            X_test = EMNIST.ByMerge.testdata()
+            Y_train = EMNIST.ByMerge.trainlabels()
+            Y_test = EMNIST.ByMerge.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}
@@ -50,10 +50,10 @@ module EMNIST_Tests
             @test size(Y_train) == (697932, 1)
             @test size(Y_test) == (116323, 1)
 
-            X_train = EMNIST.digits.traindata()
-            X_test = EMNIST.digits.testdata()
-            Y_train = EMNIST.digits.trainlabels()
-            Y_test = EMNIST.digits.testlabels()
+            X_train = EMNIST.Digits.traindata()
+            X_test = EMNIST.Digits.testdata()
+            Y_train = EMNIST.Digits.trainlabels()
+            Y_test = EMNIST.Digits.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}
@@ -63,10 +63,10 @@ module EMNIST_Tests
             @test size(Y_train) == (240000, 1)
             @test size(Y_test) == (40000, 1)
 
-            X_train = EMNIST.letters.traindata()
-            X_test = EMNIST.letters.testdata()
-            Y_train = EMNIST.letters.trainlabels()
-            Y_test = EMNIST.letters.testlabels()
+            X_train = EMNIST.Letters.traindata()
+            X_test = EMNIST.Letters.testdata()
+            Y_train = EMNIST.Letters.trainlabels()
+            Y_test = EMNIST.Letters.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}
@@ -76,10 +76,10 @@ module EMNIST_Tests
             @test size(Y_train) == (124800, 1)
             @test size(Y_test) == (20800, 1)
 
-            X_train = EMNIST.mnist.traindata()
-            X_test = EMNIST.mnist.testdata()
-            Y_train = EMNIST.mnist.trainlabels()
-            Y_test = EMNIST.mnist.testlabels()
+            X_train = EMNIST.MNIST.traindata()
+            X_test = EMNIST.MNIST.testdata()
+            Y_train = EMNIST.MNIST.trainlabels()
+            Y_test = EMNIST.MNIST.testlabels()
             @test X_train isa Array{UInt8,3}
             @test X_test isa Array{UInt8,3}
             @test Y_train isa Array{Float64,2}


### PR DESCRIPTION
Fixes #51

I think I have properly included all the data and functionality needed to integrate EMNIST into the package. It passed all tests.

I wrote very little fancy functionality and barebones tests/documentation. I plan to add rotMNIST soon and will try to improve things then time allowing. I really wanted the different datasets packaged in EMNIST to be called like EMNIST.byclass.traindata() etc. I am not sure how I implemented was the cleanest way possible, just creating a whole bunch of submodules. If you have advice on better ways to do this (passing functions outside the module inside so I do not have to redefine it every time, as well as having the using modules propagate), that would be great for future reference.

Super open to suggestions and feedback. This is my first PR in Julia (and ever!) so please be kind. Love the Package and am happy to contribute.