### PR TITLE
removing labels from features

### DIFF
--- a/src/Mutagenesis/Mutagenesis.jl
+++ b/src/Mutagenesis/Mutagenesis.jl
@@ -22,13 +22,12 @@ julia> test_x, test_y = Mutagenesis.testdata();
 julia> val_x, val_y = Mutagenesis.valdata();
 
 julia> train_x[1]
-JSON3.Object{Base.CodeUnits{UInt8, String}, SubArray{UInt64, 1, Vector{UInt64}, Tuple{UnitRange{Int64}}, true}} with 6 entries:
+Dict{Symbol, Any} with 5 entries:
   :ind1      => 1
   :inda      => 0
   :logp      => 4.23
   :lumo      => -1.246
-  :mutagenic => 1
-  :atoms     => JSON3.Object[{…
+  :atoms     => Dict{Symbol, Any}[{…
 
 julia> train_y[1]
 1

--- a/src/Mutagenesis/Mutagenesis.jl
+++ b/src/Mutagenesis/Mutagenesis.jl
@@ -85,12 +85,13 @@ function load_data(dir)
     metadata = read_data(metadata_path)
     labelkey = metadata["label"]
     targets = map(i -> i[labelkey], samples)
+    samples_without_label = map(x->delete!(copy(x), Symbol(labelkey)), samples)
     val_num = metadata["val_samples"]
     test_num = metadata["test_samples"]
     train_idxs = 1:length(samples)-val_num-test_num
     val_idxs = length(samples)-val_num-test_num+1:length(samples)-test_num
     test_idxs = length(samples)-test_num+1:length(samples)
-    samples, targets, train_idxs, val_idxs, test_idxs
+    samples_without_label, targets, train_idxs, val_idxs, test_idxs
 end
 
 read_data(path) = open(JSON3.read, path)

--- a/src/Mutagenesis/Mutagenesis.jl
+++ b/src/Mutagenesis/Mutagenesis.jl
@@ -23,11 +23,11 @@ julia> val_x, val_y = Mutagenesis.valdata();
 
 julia> train_x[1]
 Dict{Symbol, Any} with 5 entries:
-  :ind1      => 1
-  :inda      => 0
-  :logp      => 4.23
-  :lumo      => -1.246
-  :atoms     => Dict{Symbol, Any}[{…
+  :lumo  => -1.246
+  :inda  => 0
+  :logp  => 4.23
+  :ind1  => 1
+  :atoms => Dict{Symbol, Any}[Dict(:element=>"c", :bonds=>Dict{Symbol, Any}[Dic…
 
 julia> train_y[1]
 1

--- a/test/tst_mutagenesis.jl
+++ b/test/tst_mutagenesis.jl
@@ -15,7 +15,7 @@ end
     @test !any(haskey.(test_x, :mutagenic))
     @test !any(haskey.(val_x, :mutagenic))
     # test data is materialized
-    @test train_x isa AbstractVector{<:AbstractDict}
-    @test test_x isa AbstractVector{<:AbstractDict}
-    @test val_x isa AbstractVector{<:AbstractDict}
+    @test train_x isa Vector{<:Dict}
+    @test test_x isa Vector{<:Dict}
+    @test val_x isa Vector{<:Dict}
 end

--- a/test/tst_mutagenesis.jl
+++ b/test/tst_mutagenesis.jl
@@ -10,4 +10,8 @@ end
     @test length(train_x) == length(train_y) == 100
     @test length(test_x) == length(test_y) == 44
     @test length(val_x) == length(val_y) == 44
+    # test that label is not contained in features
+    @test !any(haskey.(train_x, :mutagenic))
+    @test !any(haskey.(test_x, :mutagenic))
+    @test !any(haskey.(val_x, :mutagenic))
 end

--- a/test/tst_mutagenesis.jl
+++ b/test/tst_mutagenesis.jl
@@ -14,4 +14,8 @@ end
     @test !any(haskey.(train_x, :mutagenic))
     @test !any(haskey.(test_x, :mutagenic))
     @test !any(haskey.(val_x, :mutagenic))
+    # test data is materialized
+    @test train_x isa AbstractVector{<:AbstractDict}
+    @test test_x isa AbstractVector{<:AbstractDict}
+    @test val_x isa AbstractVector{<:AbstractDict}
 end


### PR DESCRIPTION
This commits removes labels from features, because previously the labels were part of the features, which is fundamentally wrong. 
Data is materialized as a side-effect, because JSON3 does not provide a way to lazily delete this, but it should not be problem since the dataset is very small.