### PR TITLE
Update UnitTest.yml to add macOS 11

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.3', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-11]
     env:
       PYTHON: ""
     steps:


### PR DESCRIPTION
Since macOS 12 is not available, let's at least get macOS 11 in here: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#github-hosted-runners