### PR TITLE
fix CachedDataset breaking precompilation

### DIFF
--- a/src/containers/cacheddataset.jl
+++ b/src/containers/cacheddataset.jl
@@ -26,9 +26,10 @@ struct CachedDataset{T, S}
     cache::S
 end
 
+CachedDataset(source, cachesize::Int) = CachedDataset(source, 1:cachesize)
+
 CachedDataset(source, cacheidx::AbstractVector{<:Integer} = 1:numobs(source)) =
     CachedDataset(source, collect(cacheidx), make_cache(source, cacheidx))
-CachedDataset(source, cachesize::Int = numobs(source)) = CachedDataset(source, 1:cachesize)
 
 function Base.getindex(dataset::CachedDataset, i::Integer)
     _i = findfirst(==(i), dataset.cacheidx)


### PR DESCRIPTION
Fixing broken precompilation
```julia
julia> using MLDatasets
[ Info: Precompiling MLDatasets [eb30cadb-4394-5ae3-aed4-317e484a6458]
WARNING: Method definition (::Type{MLDatasets.CachedDataset{T, S} where S where T})(Any) in module MLDatasets at /home/carlo/.julia/dev/MLDatasets/src/containers/cacheddataset.jl:29 overwritten at /home/carlo/.julia/dev/MLDatasets/src/containers/cacheddataset.jl:31.
  ** incremental compilation may be fatally broken for this module **
```