### PR TITLE
Fixed matrix order in Titanic features

### DIFF
--- a/src/Titanic/Titanic.jl
+++ b/src/Titanic/Titanic.jl
@@ -153,7 +153,7 @@ julia> summary(features)
 """
 function features()
     titanic_data = readdlm(DATA, ',')
-    reshape(Matrix(hcat(titanic_data[2:end, 1], titanic_data[2:end, 3:12])), (11, 891))
+    permutedims(Matrix(hcat(titanic_data[2:end, 1], titanic_data[2:end, 3:12])), (2, 1))
 end
 
 end # module

--- a/test/tst_titanic.jl
+++ b/test/tst_titanic.jl
@@ -8,11 +8,17 @@ using MLDatasets
     X = Titanic.features()
     Y = Titanic.targets()
     names = Titanic.feature_names()
+    
+    first_row_expected = [
+        1, 3, "Braund, Mr. Owen Harris", "male", 22, 1, 0, "A/5 21171", 7.25, "", "S"
+    ]
+
     @test X isa Matrix{}
     @test Y isa Matrix{}
     @test names == ["PassengerId","Pclass", "Name", "Sex", "Age", "SibSp", "Parch", "Ticket", "Fare", "Cabin", "Embarked"]
     @test size(X) == (11, 891)
     @test size(Y) == (1, 891)
+    @test X[:, 1] == first_row_expected
 end
 
 end #module


### PR DESCRIPTION
resolves #108 

Changes:
1. Use `permutedims` instead of `reshape` to ensure that the order of the elements stay the same
2. Add a new test case that checks whether the first row in the returned matrix is the correct one.