### PR TITLE
Fix unzip errors in OGB-Datasets

### DIFF
--- a/src/datasets/graphs/ogbdataset.jl
+++ b/src/datasets/graphs/ogbdataset.jl
@@ -163,7 +163,8 @@ function makedir_ogb(fullname, url, dir = nothing)
         cd(root_dir) # Needed since `unpack` extracts in working dir
         DataDeps.unpack(local_filepath)
         unzipped = local_filepath[1:findlast('.', local_filepath)-1]
-        mv(unzipped, data_dir) 
+        # conditions when unzipped folder is our required data dir
+        (unzipped == data_dir) || mv(unzipped, data_dir) # none of them are relative path
         for (root, dirs, files) in walkdir(data_dir)
             for file in files
                 if endswith(file, r"zip|gz")


### PR DESCRIPTION
Fix errors that appear for Datasets like ogbl-collab where the zip name is collab.zip. So `mv` command throws an error in this case:
```julia
ArgumentError: '/home/deebyo/.julia/datadeps/OGBDataset/collab' exists. `force=true` is required to remove '/home/deebyo/.julia/datadeps/OGBDataset/collab' before moving.
```