### PR TITLE
Fix documentation typos for vision datasets

### DIFF
--- a/src/datasets/vision/cifar10.jl
+++ b/src/datasets/vision/cifar10.jl
@@ -48,7 +48,7 @@ per class.
 # Arguments
 
 $ARGUMENTS_SUPERVISED_ARRAY
-- `split`: selects the data partition. Can take the values `:train:` or `:test`. 
+- `split`: selects the data partition. Can take the values `:train` or `:test`. 
 
 # Fields
 

--- a/src/datasets/vision/cifar100.jl
+++ b/src/datasets/vision/cifar100.jl
@@ -58,7 +58,7 @@ two `Vector{Int}`. The variables returned are the coarse label(s)
 # Arguments
 
 $ARGUMENTS_SUPERVISED_ARRAY
-- `split`: selects the data partition. Can take the values `:train:` or `:test`. 
+- `split`: selects the data partition. Can take the values `:train` or `:test`. 
 
 # Fields
 

--- a/src/datasets/vision/emnist.jl
+++ b/src/datasets/vision/emnist.jl
@@ -50,7 +50,7 @@ at https://arxiv.org/abs/1702.05373v1.
 # Arguments
 
 - `name`: name of the EMNIST dataset. Possible values are: `:balanced, :byclass, :bymerge, :digits, :letters, :mnist`.
-- `split`: selects the data partition. Can take the values `:train:` or `:test`. 
+- `split`: selects the data partition. Can take the values `:train` or `:test`. 
 $ARGUMENTS_SUPERVISED_ARRAY
 
 # Fields

--- a/src/datasets/vision/mnist.jl
+++ b/src/datasets/vision/mnist.jl
@@ -50,7 +50,7 @@ the 10 possible digits (0-9).
 # Arguments
 
 $ARGUMENTS_SUPERVISED_ARRAY
-- `split`: selects the data partition. Can take the values `:train:` or `:test`. 
+- `split`: selects the data partition. Can take the values `:train` or `:test`. 
 
 # Fields
 

--- a/src/datasets/vision/svhn2.jl
+++ b/src/datasets/vision/svhn2.jl
@@ -58,7 +58,7 @@ additional to use as extra training data.
 # Arguments
 
 $ARGUMENTS_SUPERVISED_ARRAY
-- `split`: selects the data partition. Can take the values `:train:`, `:test` or `:extra`. 
+- `split`: selects the data partition. Can take the values `:train`, `:test` or `:extra`. 
 
 # Fields
 


### PR DESCRIPTION
An extra colon seems to have snuck into the documentation string for most of the vision datasets.

That is all.