### PR TITLE
require explicit Pickle import in load_pytorch

### DIFF
--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -23,8 +23,8 @@ include("require.jl") # export @require
 @require import JSON3="0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 @require import DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 @require import ImageShow="4e3cecfd-b093-5904-9786-8bbb286a6a31"
-@require import Pickle="fbb45041-c46e-462f-888f-7c521cafbc2c"
 # @lazy import NPZ # lazy imported by FileIO
+@lazy import Pickle="fbb45041-c46e-462f-888f-7c521cafbc2c"
 @lazy import MAT="23992714-dd62-5051-b70f-ba57cb901cac"
 @lazy import HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 # @lazy import JLD2

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -9,6 +9,7 @@ using MLUtils: getobs, numobs, AbstractDataContainer
 using Glob
 using DelimitedFiles: readdlm
 using FileIO
+import CSV
 using LazyModules: @lazy
 
 include("require.jl") # export @require
@@ -22,10 +23,9 @@ include("require.jl") # export @require
 @require import JSON3="0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 @require import DataFrames="a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 @require import ImageShow="4e3cecfd-b093-5904-9786-8bbb286a6a31"
+@require import Pickle="fbb45041-c46e-462f-888f-7c521cafbc2c"
 # @lazy import NPZ # lazy imported by FileIO
-@lazy import Pickle="fbb45041-c46e-462f-888f-7c521cafbc2c"
 @lazy import MAT="23992714-dd62-5051-b70f-ba57cb901cac"
-import CSV
 @lazy import HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 # @lazy import JLD2
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -25,6 +25,7 @@ function read_npz(path)
 end
 
 function read_pytorch(path)
+    assert_imported(Pickle._lazy_pkgid)
     return Pickle.Torch.THload(path)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using ImageShow
 using ColorTypes
 using FixedPointNumbers
 using JSON3
+using Pickle
 
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 


### PR DESCRIPTION
Moving `Pickle` to required packages. This means we have to load `Pickle` explicitly for Planetoid graph datasets.