### PR TITLE
Unify all Graph Dataset types

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -227,3 +227,33 @@ function edgeindex2adjlist(s, t, num_nodes; inneigs=false)
     end
     return adj
 end
+
+"""
+    GraphDataset{<:AbstractGraph} <: AbstractDataset
+
+GraphDataset
+"""
+struct GraphDataset{T<:AbstractGraph} <: AbstractDataset
+    metadata::Dict{String, Any}
+    graphs::Vector{T}
+    graphs_data::NamedTuple
+end
+
+Base.length(data::GraphDataset) = length(data.graphs)
+
+function Base.getindex(data::GraphDataset, ::Colon)
+    if isempty(graph_data)
+        return length(data.graphs) == 1 ? data.graphs[1] : data.graphs
+    else
+        return (; data.graphs, data.graph_data)
+    end
+end
+
+function Base.getindex(data::GraphDataset, i::Int)
+    if isempty(graph_data)
+        return getobs(data.graphs, i)
+    else
+        return getobs((; data.graphs, data.graph_data.labels), i)
+    end
+end
+


### PR DESCRIPTION
Related to: #169 

Added the GraphDataset struct which can replace all custom structs for each Data source.

The metadata will have fields like OGBDatasets metadata, including name, source, etc. We also can add data citations. This is also required for saving datasets in parquet format, as defining storing method for each struct is troublesome.

@CarloLucibello if you can review the initial struct, I can start with replacing the data source structs. 