### PR TITLE
Corrects docstring for the `as_df` keyword

### DIFF
--- a/src/abstract_datasets.jl
+++ b/src/abstract_datasets.jl
@@ -99,9 +99,9 @@ const ARGUMENTS_SUPERVISED_TABLE = """
 
 const FIELDS_SUPERVISED_TABLE = """
 - `metadata`: A dictionary containing additional information on the dataset.
-- `features`: The data features. An array if `as_df=true`, otherwise a dataframe.
-- `targets`: The targets for supervised learning. An array if `as_df=true`, otherwise a dataframe.
-- `dataframe`: A dataframe containing both `features` and `targets`. It is `nothing` if `as_df=false`.
+- `features`: The data features. An array if `as_df=false`, otherwise a dataframe.
+- `targets`: The targets for supervised learning. An array if `as_df=false`, otherwise a dataframe.
+- `dataframe`: A dataframe containing both `features` and `targets`. It is `nothing` if `as_df=false`, otherwise a dataframed.
 """
 
 const METHODS_SUPERVISED_TABLE = """


### PR DESCRIPTION
The specific behavior of the `as_df` keyword stated in the docstring template for specific fields is contrary to the keyword's main description, the keyword meaning and to its actual behavior: `as_df=false` for plain arrays, `as_df=true` for dataframes.