### PR TITLE
Support multiple labels for nodes, edges and graphs

### DIFF
--- a/src/datasets/graphs/tudataset.jl
+++ b/src/datasets/graphs/tudataset.jl
@@ -72,13 +72,13 @@ function TUDataset(name; dir=nothing)
     # LOAD OPTIONAL FILES IF EXIST
     
     node_labels = isfile(joinpath(d, "$(name)_node_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_node_labels.txt"), Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_node_labels.txt"), ',', Int) |> vec :
                     nothing
     edge_labels = isfile(joinpath(d, "$(name)_edge_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_edge_labels.txt"), Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_edge_labels.txt"), ',', Int) |> vec :
                     nothing
     graph_labels = isfile(joinpath(d, "$(name)_graph_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_graph_labels.txt"), Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_graph_labels.txt"), ',', Int) |> vec :
                     nothing
 
     node_attributes = isfile(joinpath(d, "$(name)_node_attributes.txt")) ?

--- a/src/datasets/graphs/tudataset.jl
+++ b/src/datasets/graphs/tudataset.jl
@@ -72,13 +72,13 @@ function TUDataset(name; dir=nothing)
     # LOAD OPTIONAL FILES IF EXIST
     
     node_labels = isfile(joinpath(d, "$(name)_node_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_node_labels.txt"), ',', Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_node_labels.txt"), ',', Int)' |> collect |> maybesqueeze :
                     nothing
     edge_labels = isfile(joinpath(d, "$(name)_edge_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_edge_labels.txt"), ',', Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_edge_labels.txt"), ',', Int)' |> collect |> maybesqueeze :
                     nothing
     graph_labels = isfile(joinpath(d, "$(name)_graph_labels.txt")) ?
-                    readdlm(joinpath(d, "$(name)_graph_labels.txt"), ',', Int) |> vec :
+                    readdlm(joinpath(d, "$(name)_graph_labels.txt"), ',', Int)' |> collect |> maybesqueeze :
                     nothing
 
     node_attributes = isfile(joinpath(d, "$(name)_node_attributes.txt")) ?

--- a/test/datasets/graphs.jl
+++ b/test/datasets/graphs.jl
@@ -252,3 +252,37 @@ end
         end
     end
 end
+
+@testset "TUDataset - Cuneiform" begin
+    data  = TUDataset("Cuneiform")
+
+    @test data.num_nodes == 5680
+    @test data.num_edges == 23922
+    @test data.num_graphs == 267
+
+    @test data.num_nodes == sum(g->g.num_nodes, data.graphs)
+    @test data.num_edges == sum(g->g.num_edges, data.graphs)
+    @test data.num_edges == sum(g->length(g.edge_index[1]), data.graphs)
+    @test data.num_edges == sum(g->length(g.edge_index[2]), data.graphs)
+    @test data.num_graphs == length(data) == length(data.graphs)
+
+    i = rand(1:length(data))
+    di = data[i]
+    @test di isa NamedTuple
+    g, targets = di.graphs, di.targets
+    @test targets isa Int
+    @test g isa Graph
+    @test all(1 .<= g.edge_index[1] .<= g.num_nodes)
+    @test all(1 .<= g.edge_index[2] .<= g.num_nodes)
+
+    # graph data
+    @test size(data.graph_data.targets) == (data.num_graphs, )
+
+    # node data
+    @test size(g.node_data.features) == (3, g.num_nodes)
+    @test size(g.node_data.targets) == (2, g.num_nodes)
+
+    # edge data
+    @test size(g.edge_data.features) == (2, g.num_edges)
+    @test size(g.edge_data.targets) == (g.num_edges, )
+end


### PR DESCRIPTION
Our `TUDataset` implementation didn't support a node, edge or graph having multiple labels. A simple change in delimiter allows us to read all the labels correctly. Ideally closes #195 

ToDo:
 - [ ] Tests for Cuneiform