### PR TITLE
Add TemporalBrains dataset

### DIFF
--- a/docs/src/datasets/graphs.md
+++ b/docs/src/datasets/graphs.md
@@ -32,4 +32,5 @@ Reddit
 TUDataset
 METRLA
 PEMSBAY
+TemporalBrains
 ```

--- a/src/MLDatasets.jl
+++ b/src/MLDatasets.jl
@@ -135,6 +135,8 @@ include("datasets/graphs/metrla.jl")
 export METRLA
 include("datasets/graphs/pemsbay.jl")
 export PEMSBAY
+include("datasets/graphs/temporalbrains.jl")
+export TemporalBrains
 
 # Meshes
 
@@ -156,6 +158,7 @@ function __init__()
     __init__tudataset()
     __init__metrla()
     __init__pemsbay()
+    __init__temporalbrains()
 
     # misc
     __init__iris()

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -57,9 +57,9 @@ end
 
 The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the [Human Connectome Project (HCP)](https://www.humanconnectome.org/study/hcp-young-adult/document/extensively-processed-fmri-data-documentation).
 
-The number of nodes is fixed for each of the 27 snapshots at 102, instead the edges change over time.
+The number of nodes is fixed for each of the 27 snapshots at 102, instead, the edges change over time.
     
-Each node feature, representing its average activation at each snapshot, is contained in `node_data`.
+The feature of a node represents the average activation of the node in that snapshot.
 
 Each graph has a label representing their gender ("M" for male and "F" for female) and age range (22-25, 26-30,31-35 and 36+) contained as a named tuple in `graph_data`.
 

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -1,4 +1,4 @@
-function __init__metrla()
+function __init__temporalbrains()
     DEPNAME = "TemporalBrains"
     LINK = "http://www-sop.inria.fr/members/Aurora.Rossi/index.html"
     register(ManualDataDep(DEPNAME,
@@ -9,7 +9,7 @@ function __init__metrla()
 end
 
 struct TemporalBrains <: AbstractDataset
-    graphs::Vector{Graph}
+    graphs::Vector{TemporalSnapshotsGraphs}
 end
 
 function tb_datadir(dir = nothing)
@@ -25,4 +25,22 @@ function tb_datadir(dir = nothing)
     end
     @assert isdir(dir)
     return dir
+end
+
+function create_dataset(dir)
+    name_filelabels = joinpath(dir, "LabelledTBN", "labels.txt")
+    filelabels = open(name_filelabels, "r")
+    temporalgraphs = Vector{MLDatasets.TemporalSnapshotsGrapgs}(undef, 1000)
+
+    for (i,line) in enumerate(eachline(filelabels))
+        id, gender, age = split(line)
+        
+        name_network_file = joinpath(dir, "LabelledTBN", "networks", id * "_ws60_wo30_tuk0_pearson_schaefer_100.txt")
+        
+        data = readdlm(name_network_file,','; skipstart = 1) 
+        edata = [data[data[:,3].==t,4] for t in 1:27]
+
+        temporalgraphs[i] = TemporalSnapshotsGraphs(num_nodes=ones(27).*102, edge_index = (data[:,1],data[:,2],data[:,3]), edge_data = edata, graph_data= (g = gender, a = age))
+    end
+    return temporalgraphs
 end

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -57,8 +57,9 @@ end
 
 The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the Human Connectome Project (HCP).
 
-The number of nodes is fixed for each of the 27 snapshots at 102, instead the edge weights change their values over time.
-The edge weights are contained in a vector of 27 arrays in the `edge_data` field of the `TemporalSnapshotsGraph`. 
+The number of nodes is fixed for each of the 27 snapshots at 102, instead the edges change over time.
+    
+Each node feature, representing its average activation at each snapshot, is contained in `node_data`.
 
 Each graph has a label representing their gender ("M" for male and "F" for female) and age range (22-25, 26-30,31-35 and 36+) contained as a named tuple in `graph_data`.
 

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -8,9 +8,6 @@ function __init__temporalbrains()
                            """))
 end
 
-struct TemporalBrains <: AbstractDataset
-    graphs::Vector{TemporalSnapshotsGraphs}
-end
 
 function tb_datadir(dir = nothing)
     dir = isnothing(dir) ? datadep"TemporalBrains" : dir
@@ -27,7 +24,7 @@ function tb_datadir(dir = nothing)
     return dir
 end
 
-function create_dataset(dir)
+function create_tbdataset(dir)
     name_filelabels = joinpath(dir, "LabelledTBN", "labels.txt")
     filelabels = open(name_filelabels, "r")
     temporalgraphs = Vector{MLDatasets.TemporalSnapshotsGrapgs}(undef, 1000)
@@ -40,7 +37,22 @@ function create_dataset(dir)
         data = readdlm(name_network_file,','; skipstart = 1) 
         edata = [data[data[:,3].==t,4] for t in 1:27]
 
-        temporalgraphs[i] = TemporalSnapshotsGraphs(num_nodes=ones(27).*102, edge_index = (data[:,1],data[:,2],data[:,3]), edge_data = edata, graph_data= (g = gender, a = age))
+        temporalgraphs[i] = TemporalSnapshotsGraph(num_nodes=ones(27).*102, edge_index = (data[:,1],data[:,2],data[:,3]), edge_data = edata, graph_data= (g = gender, a = age))
     end
     return temporalgraphs
 end
+
+struct TemporalBrains <: AbstractDataset
+    graphs::Vector{TemporalSnapshotsGraph}
+end
+
+function TemporalBrains(; dir=nothing)
+    create_default_dir("TemporalBrains")
+    dir = tb_datadir(dir)
+    graphs = create_tbdataset(dir)
+    return TemporalBrains(graphs)
+end
+
+Base.length(d::TemporalBrains) = length(d.graphs)
+Base.getindex(d::TemporalBrains, ::Colon) = d.graphs[1]
+Base.getindex(d::TemporalBrains, i) = getindex(d.graphs, i)

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -53,7 +53,7 @@ function create_tbdataset(dir, thre)
 end
 
 """
-    TemporalBrains(; dir=nothing, threshold_value = 0.6)
+    TemporalBrains(; dir = nothing, threshold_value = 0.6)
 
 The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the Human Connectome Project (HCP).
 

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -24,32 +24,54 @@ function tb_datadir(dir = nothing)
     return dir
 end
 
-function create_tbdataset(dir)
+
+function create_tbdataset(dir, thre)
     name_filelabels = joinpath(dir, "LabelledTBN", "labels.txt")
     filelabels = open(name_filelabels, "r")
-    temporalgraphs = Vector{MLDatasets.TemporalSnapshotsGrapgs}(undef, 1000)
+    temporalgraphs = Vector{MLDatasets.TemporalSnapshotsGraph}(undef, 1000)
 
     for (i,line) in enumerate(eachline(filelabels))
         id, gender, age = split(line)
-        
         name_network_file = joinpath(dir, "LabelledTBN", "networks", id * "_ws60_wo30_tuk0_pearson_schaefer_100.txt")
         
-        data = readdlm(name_network_file,','; skipstart = 1) 
-        edata = [data[data[:,3].==t,4] for t in 1:27]
+        data = readdlm(name_network_file,',',Float32; skipstart = 1) 
+    
+        data_thre = view(data,view(data,:,4) .> thre,:)
+        data_thre_int = Int.(view(data_thre,:,1:3))
 
-        temporalgraphs[i] = TemporalSnapshotsGraph(num_nodes=ones(27).*102, edge_index = (data[:,1],data[:,2],data[:,3]), edge_data = edata, graph_data= (g = gender, a = age))
+        activation = [zeros(Float32, 102) for _ in 1:27]
+        for t in 1:27
+             for n in 1:102
+                rows = (view(data_thre_int,:,1).==n .&& view(data_thre_int,:,3).==t)
+                activation[t][n] = mean(view(data_thre,rows,4))
+             end
+        end
+
+        temporalgraphs[i] = TemporalSnapshotsGraph(num_nodes=ones(Int,27)*102, edge_index = (data_thre_int[:,1], data_thre_int[:,2], data_thre_int[:,3]), node_data= activation, graph_data= (g = gender, a = age))
     end
     return temporalgraphs
 end
 
+"""
+    TemporalBrains(; dir=nothing, threshold_value = 0.6)
+
+The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the Human Connectome Project (HCP).
+
+The number of nodes is fixed for each of the 27 snapshots at 102, instead the edge weights change their values over time.
+The edge weights are contained in a vector of 27 arrays in the `edge_data` field of the `TemporalSnapshotsGraph`. 
+
+Each graph has a label representing their gender ("M" for male and "F" for female) and age range (22-25, 26-30,31-35 and 36+) contained as a named tuple in `graph_data`.
+
+The `threshold_value` is used to binarize the edge weights and is set to 0.6 by default.
+"""
 struct TemporalBrains <: AbstractDataset
-    graphs::Vector{TemporalSnapshotsGraph}
+    graphs::Vector{MLDatasets.TemporalSnapshotsGraph}
 end
 
-function TemporalBrains(; dir=nothing)
+function TemporalBrains(;threshold_value = 0.6, dir=nothing)
     create_default_dir("TemporalBrains")
     dir = tb_datadir(dir)
-    graphs = create_tbdataset(dir)
+    graphs = create_tbdataset(dir, threshold_value)
     return TemporalBrains(graphs)
 end
 

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -42,7 +42,7 @@ function create_tbdataset(dir, thre)
         activation = [zeros(Float32, 102) for _ in 1:27]
         for t in 1:27
              for n in 1:102
-                rows = (view(data_thre_int,:,1).==n .&& view(data_thre_int,:,3).==t)
+                rows = ((view(data_thre_int,:,1).==n) .& (view(data_thre_int,:,3).==t))
                 activation[t][n] = mean(view(data_thre,rows,4))
              end
         end

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -1,0 +1,28 @@
+function __init__metrla()
+    DEPNAME = "TemporalBrains"
+    LINK = "http://www-sop.inria.fr/members/Aurora.Rossi/index.html"
+    register(ManualDataDep(DEPNAME,
+                           """
+                           Dataset: $DEPNAME
+                           Website : $LINK
+                           """))
+end
+
+struct TemporalBrains <: AbstractDataset
+    graphs::Vector{Graph}
+end
+
+function tb_datadir(dir = nothing)
+    dir = isnothing(dir) ? datadep"TemporalBrains" : dir
+    LINK = "http://www-sop.inria.fr/members/Aurora.Rossi/data/LabelledTBN.zip"
+    if length(readdir((dir))) == 0
+        DataDeps.fetch_default(LINK, dir)
+        currdir = pwd()
+        cd(dir) # Needed since `unpack` extracts in working dir
+        DataDeps.unpack(joinpath(dir, "LabelledTBN.zip"))
+        # conditions when unzipped folder is our required data dir
+        cd(currdir)
+    end
+    @assert isdir(dir)
+    return dir
+end

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -55,7 +55,7 @@ end
 """
     TemporalBrains(; dir = nothing, threshold_value = 0.6)
 
-The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the Human Connectome Project (HCP).
+The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the [Human Connectome Project (HCP)](https://www.humanconnectome.org/study/hcp-young-adult/document/extensively-processed-fmri-data-documentation).
 
 The number of nodes is fixed for each of the 27 snapshots at 102, instead the edges change over time.
     

--- a/src/datasets/graphs/temporalbrains.jl
+++ b/src/datasets/graphs/temporalbrains.jl
@@ -55,13 +55,13 @@ end
 """
     TemporalBrains(; dir = nothing, threshold_value = 0.6)
 
-The TemporalBrains dataset contains a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data from the [Human Connectome Project (HCP)](https://www.humanconnectome.org/study/hcp-young-adult/document/extensively-processed-fmri-data-documentation).
+The TemporalBrains dataset contains a collection of temporal brain networks (as `TemporalSnapshotsGraph`s) of 1000 subjects obtained from resting-state fMRI data from the [Human Connectome Project (HCP)](https://www.humanconnectome.org/study/hcp-young-adult/document/extensively-processed-fmri-data-documentation).
 
-The number of nodes is fixed for each of the 27 snapshots at 102, instead, the edges change over time.
+The number of nodes is fixed for each of the 27 snapshots at 102, while the edges change over time.
     
-The feature of a node represents the average activation of the node in that snapshot.
+For each `Graph` snapshot, the feature of a node represents the average activation of the node during that snapshot and it is contained in `Graphs.node_data`.
 
-Each graph has a label representing their gender ("M" for male and "F" for female) and age range (22-25, 26-30,31-35 and 36+) contained as a named tuple in `graph_data`.
+Each `TemporalSnapshotsGraph` has a label representing their gender ("M" for male and "F" for female) and age range (22-25, 26-30, 31-35 and 36+) contained as a named tuple in `graph_data`.
 
 The `threshold_value` is used to binarize the edge weights and is set to 0.6 by default.
 """

--- a/test/datasets/graphs_no_ci.jl
+++ b/test/datasets/graphs_no_ci.jl
@@ -364,3 +364,16 @@ end
     @test g.num_edges == 2694
     @test all(g.node_data.features[1][:,:,1][2:end,1] == g.node_data.targets[1][:,:,1][1:end-1])
 end
+
+@testset "TemporalBrains" begin
+    data = TemporalBrains()
+    @test data isa AbstractDataset
+    @test length(data) == 1000
+    g = data[1]
+    @test g isa MLDatasets.TemporalSnapshotsGraph
+
+    @test g.num_nodes == [102 for _ in 1:27]
+    @test g.num_snapshots == 27
+    @test g.snapshots[1] isa MLDatasets.Graph
+    @test length(g.snapshots[1].node_data) == 102
+end


### PR DESCRIPTION
This PR adds the `TemporalBrains` dataset,  a collection of temporal brain networks of 1000 subjects obtained from resting-state fMRI data.